### PR TITLE
Implement sin/cos for VM and animate slide

### DIFF
--- a/iv.h
+++ b/iv.h
@@ -94,3 +94,17 @@ static inline iv iv_inv(iv x) {
         if_then_else(x.lo > 0 | x.hi < 0 | (x.lo < 0 & x.hi <= 0), 1/x.lo, (float4){0} + 1/0.0f),
     };
 }
+
+static inline iv iv_sin(iv x) {
+    return (iv){
+        __builtin_elementwise_sin(x.lo),
+        __builtin_elementwise_sin(x.hi),
+    };
+}
+
+static inline iv iv_cos(iv x) {
+    return (iv){
+        __builtin_elementwise_cos(x.lo),
+        __builtin_elementwise_cos(x.hi),
+    };
+}

--- a/iv2d_vm.c
+++ b/iv2d_vm.c
@@ -4,7 +4,7 @@
 #include <string.h>
 
 struct inst {
-    enum { RET,IMM,UNI,X,Y,ABS,SQT,SQR,INV,ADD,SUB,MUL,MIN,MAX} op;
+    enum { RET,IMM,UNI,X,Y,ABS,SQT,SQR,INV,SIN,COS,ADD,SUB,MUL,MIN,MAX} op;
     int          lhs,rhs;
     float        imm;
     float const *ptr;
@@ -42,6 +42,8 @@ int iv2d_abs   (builder *b, int v) { return push(b, (struct inst){.op=ABS, .rhs=
 int iv2d_sqrt  (builder *b, int v) { return push(b, (struct inst){.op=SQT, .rhs=v}); }
 int iv2d_square(builder *b, int v) { return push(b, (struct inst){.op=SQR, .rhs=v}); }
 int iv2d_inv   (builder *b, int v) { return push(b, (struct inst){.op=INV, .rhs=v}); }
+int iv2d_sin   (builder *b, int v) { return push(b, (struct inst){.op=SIN, .rhs=v}); }
+int iv2d_cos   (builder *b, int v) { return push(b, (struct inst){.op=COS, .rhs=v}); }
 
 int iv2d_sub(builder *b, int l, int r) { return push(b, (struct inst){.op=SUB, .lhs=l, .rhs=r}); }
 int iv2d_add(builder *b, int l, int r) { return push(b, (struct inst){.op=ADD, .lhs=l, .rhs=r}); }
@@ -84,6 +86,8 @@ static iv run_program(struct iv2d_region const *region, iv x, iv y) {
             case SQT: *next++ = iv_sqrt  (           v[inst->rhs]); break;
             case SQR: *next++ = iv_square(           v[inst->rhs]); break;
             case INV: *next++ = iv_inv   (           v[inst->rhs]); break;
+            case SIN: *next++ = iv_sin   (           v[inst->rhs]); break;
+            case COS: *next++ = iv_cos   (           v[inst->rhs]); break;
             case ADD: *next++ = iv_add(v[inst->lhs], v[inst->rhs]); break;
             case SUB: *next++ = iv_sub(v[inst->lhs], v[inst->rhs]); break;
             case MUL: *next++ = iv_mul(v[inst->lhs], v[inst->rhs]); break;

--- a/iv2d_vm.h
+++ b/iv2d_vm.h
@@ -23,3 +23,5 @@ int iv2d_abs   (struct iv2d_builder*, int);
 int iv2d_sqrt  (struct iv2d_builder*, int);
 int iv2d_square(struct iv2d_builder*, int);
 int iv2d_inv   (struct iv2d_builder*, int);
+int iv2d_sin   (struct iv2d_builder*, int);
+int iv2d_cos   (struct iv2d_builder*, int);

--- a/iv_test.c
+++ b/iv_test.c
@@ -1,5 +1,6 @@
 #include "iv.h"
 #include "test.h"
+#include <math.h>
 
 static void test_add(void) {
     iv z = iv_add((iv){{3},{4}}, (iv){{5},{6}});
@@ -163,6 +164,33 @@ static void test_inv(void) {
     }
 }
 
+static void test_sin_cos(void) {
+    {
+        iv z = iv_sin(as_iv(0.0f));
+        expect(equiv(z.lo[0], 0.0f));
+        expect(equiv(z.hi[0], 0.0f));
+    }
+    {
+        iv z = iv_cos(as_iv(0.0f));
+        expect(equiv(z.lo[0], 1.0f));
+        expect(equiv(z.hi[0], 1.0f));
+    }
+    {
+        float const half_pi = 1.57079632679f;
+        iv z = iv_sin(as_iv(half_pi));
+        float const s = sinf(half_pi);
+        expect(equiv(z.lo[0], s));
+        expect(equiv(z.hi[0], s));
+    }
+    {
+        float const half_pi = 1.57079632679f;
+        iv z = iv_cos(as_iv(half_pi));
+        float const c = cosf(half_pi);
+        expect(equiv(z.lo[0], c));
+        expect(equiv(z.hi[0], c));
+    }
+}
+
 int main(void) {
     test_add();
     test_sub();
@@ -174,5 +202,6 @@ int main(void) {
     test_square();
     test_abs();
     test_inv();
+    test_sin_cos();
     return 0;
 }

--- a/slides/vm_union.c
+++ b/slides/vm_union.c
@@ -17,11 +17,15 @@ static struct iv2d_region const* create(float const *w, float const *h, float co
     }
     int orbit_circle;
     {
-        // TODO: add iv2d_sin/iv2d_cos, animate orbit circle using iv2d_uni(b,t)
-        (void)t;
-        int dx2 = iv2d_square(b, iv2d_sub(b, iv2d_x(b), iv2d_imm(b,300)));
-        int dy2 = iv2d_square(b, iv2d_sub(b, iv2d_y(b), iv2d_imm(b,200)));
-        int len = iv2d_sqrt(b, iv2d_add(b, dx2, dy2));
+        int const ox = iv2d_add(b, cx,
+                                iv2d_mul(b, iv2d_imm(b, 100),
+                                         iv2d_cos(b, iv2d_uni(b,t)))),
+                  oy = iv2d_add(b, cy,
+                                iv2d_mul(b, iv2d_imm(b, 100),
+                                         iv2d_sin(b, iv2d_uni(b,t))));
+        int const dx2 = iv2d_square(b, iv2d_sub(b, iv2d_x(b), ox)),
+                  dy2 = iv2d_square(b, iv2d_sub(b, iv2d_y(b), oy)),
+                  len = iv2d_sqrt(b, iv2d_add(b, dx2, dy2));
         orbit_circle = iv2d_sub(b, len, iv2d_imm(b,100));
     }
     return iv2d_ret(b, iv2d_min(b, center_circle, orbit_circle));


### PR DESCRIPTION
## Summary
- add `iv_sin` and `iv_cos` interval helpers
- expose and execute `iv2d_sin`/`iv2d_cos` in the VM
- animate `vm_union` slide with trigonometric motion
- test new vector sin/cos operations

## Testing
- `ninja -v out/iv_test.ok out/iv2d_vm_test.ok`

------
https://chatgpt.com/codex/tasks/task_e_685292c1c2048326ba676f6fd965d2fa