### PR TITLE
Add coverage for iv2d regions

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -33,6 +33,10 @@ build out/iv2d_vm.o:       compile  iv2d_vm.c
 build out/iv2d_vm_test.o:  compile  iv2d_vm_test.c
 build out/iv2d_vm_test:    link out/iv2d_vm_test.o out/iv2d_vm.o
 build out/iv2d_vm_test.ok: run  out/iv2d_vm_test
+build out/iv2d_regions_test.o: compile iv2d_regions_test.c
+build out/iv2d_regions_test:   link out/iv2d_regions_test.o out/iv2d.o out/iv2d_regions.o
+    flags = -lm
+build out/iv2d_regions_test.ok: run out/iv2d_regions_test
 
 build out/stb_image_write.o: compile stb_image_write.c
     flags = -fno-sanitize=integer

--- a/iv2d_regions_test.c
+++ b/iv2d_regions_test.c
@@ -1,0 +1,64 @@
+#include "iv2d_regions.h"
+#include "iv2d.h"
+#include "test.h"
+
+struct cover_ctx {
+    int calls;
+    float l,t,r,b,cov;
+};
+
+static void record(void *arg, float l,float t,float r,float b,float cov) {
+    struct cover_ctx *ctx = arg;
+    ctx->calls++;
+    ctx->l=l; ctx->t=t; ctx->r=r; ctx->b=b; ctx->cov=cov;
+}
+
+static void test_circle(void) {
+    struct iv2d_circle c = {.region={iv2d_circle}, 0,0,1};
+    iv v = c.region.eval(&c.region, as_iv(0), as_iv(0));
+    expect(equiv(v.lo[0], -1));
+    expect(equiv(v.hi[0], -1));
+
+    v = c.region.eval(&c.region, as_iv(1), as_iv(0));
+    expect(equiv(v.lo[0], 0));
+    expect(equiv(v.hi[0], 0));
+}
+
+static void test_union(void) {
+    struct iv2d_circle a = {.region={iv2d_circle}, 0,0,1};
+    struct iv2d_circle b = {.region={iv2d_circle}, 2,0,1};
+    struct iv2d_region const *subs[] = {&a.region,&b.region};
+    struct iv2d_setop u = {.region={iv2d_union}, subs, 2};
+
+    iv v = u.region.eval(&u.region, as_iv(0), as_iv(0));
+    expect(equiv(v.lo[0], -1));
+    expect(equiv(v.hi[0], -1));
+
+    v = u.region.eval(&u.region, as_iv(1), as_iv(0));
+    expect(equiv(v.lo[0], 0));
+    expect(equiv(v.hi[0], 0));
+}
+
+static void test_cover(void) {
+    struct iv2d_circle big = {.region={iv2d_circle}, 0,0,10};
+    struct cover_ctx ctx = {0};
+    iv2d_cover(&big.region, -1,-1,1,1, 0, record,&ctx);
+    expect(ctx.calls == 1);
+    expect(equiv(ctx.l,-1));
+    expect(equiv(ctx.t,-1));
+    expect(equiv(ctx.r, 1));
+    expect(equiv(ctx.b, 1));
+    expect(equiv(ctx.cov,1));
+
+    struct iv2d_circle far = {.region={iv2d_circle}, 5,0,1};
+    ctx.calls = 0;
+    iv2d_cover(&far.region, -1,-1,1,1, 0, record,&ctx);
+    expect(ctx.calls == 0);
+}
+
+int main(void) {
+    test_circle();
+    test_union();
+    test_cover();
+    return 0;
+}

--- a/iv2d_regions_test.c
+++ b/iv2d_regions_test.c
@@ -15,13 +15,14 @@ static void record(void *arg, float l,float t,float r,float b,float cov) {
 
 static void test_circle(void) {
     struct iv2d_circle c = {.region={iv2d_circle}, 0,0,1};
+
     iv v = c.region.eval(&c.region, as_iv(0), as_iv(0));
     expect(equiv(v.lo[0], -1));
     expect(equiv(v.hi[0], -1));
 
-    v = c.region.eval(&c.region, as_iv(1), as_iv(0));
-    expect(equiv(v.lo[0], 0));
-    expect(equiv(v.hi[0], 0));
+    v = c.region.eval(&c.region, as_iv(1.5f), as_iv(0));
+    expect(equiv(v.lo[0], 0.5f));
+    expect(equiv(v.hi[0], 0.5f));
 }
 
 static void test_union(void) {
@@ -34,25 +35,25 @@ static void test_union(void) {
     expect(equiv(v.lo[0], -1));
     expect(equiv(v.hi[0], -1));
 
-    v = u.region.eval(&u.region, as_iv(1), as_iv(0));
-    expect(equiv(v.lo[0], 0));
-    expect(equiv(v.hi[0], 0));
+    v = u.region.eval(&u.region, as_iv(1.5f), as_iv(0));
+    expect(equiv(v.lo[0], -0.5f));
+    expect(equiv(v.hi[0], -0.5f));
 }
 
 static void test_cover(void) {
     struct iv2d_circle big = {.region={iv2d_circle}, 0,0,10};
     struct cover_ctx ctx = {0};
-    iv2d_cover(&big.region, -1,-1,1,1, 0, record,&ctx);
+    iv2d_cover(&big.region, 0,0,2,2, 0, record,&ctx);
     expect(ctx.calls == 1);
-    expect(equiv(ctx.l,-1));
-    expect(equiv(ctx.t,-1));
-    expect(equiv(ctx.r, 1));
-    expect(equiv(ctx.b, 1));
+    expect(equiv(ctx.l,0));
+    expect(equiv(ctx.t,0));
+    expect(equiv(ctx.r,2));
+    expect(equiv(ctx.b,2));
     expect(equiv(ctx.cov,1));
 
     struct iv2d_circle far = {.region={iv2d_circle}, 5,0,1};
     ctx.calls = 0;
-    iv2d_cover(&far.region, -1,-1,1,1, 0, record,&ctx);
+    iv2d_cover(&far.region, 0,0,2,2, 0, record,&ctx);
     expect(ctx.calls == 0);
 }
 


### PR DESCRIPTION
## Summary
- create `iv2d_regions_test` exercising circle and union operations
- verify `iv2d_cover` on fully covered and empty regions
- compile and run new test in build system

## Testing
- `ninja -f build.ninja`

------
https://chatgpt.com/codex/tasks/task_e_6852b307de7083269e757464db7ead1b