### PR TITLE
Add fp16 iv16 support

### DIFF
--- a/iv.h
+++ b/iv.h
@@ -3,6 +3,9 @@
 typedef float __attribute__((vector_size(16))) float4;
 typedef   int __attribute__((vector_size(16)))   int4;
 
+typedef _Float16 __attribute__((vector_size(8))) float4h;
+typedef short    __attribute__((vector_size(8)))  int4h;
+
 static inline float4 if_then_else(int4 mask, float4 t, float4 e) {
     return (float4)( ( mask & (int4)t)
                    | (~mask & (int4)e) );
@@ -92,5 +95,106 @@ static inline iv iv_inv(iv x) {
     return (iv) {
         if_then_else(x.lo > 0 | x.hi < 0 | (x.lo >= 0 & x.hi > 0), 1/x.hi, (float4){0} - 1/0.0f),
         if_then_else(x.lo > 0 | x.hi < 0 | (x.lo < 0 & x.hi <= 0), 1/x.lo, (float4){0} + 1/0.0f),
+    };
+}
+
+static inline float4h if_then_else16(int4h mask, float4h t, float4h e) {
+    return (float4h)( (mask & (int4h)t)
+                    | (~mask & (int4h)e) );
+}
+
+static inline float4h when16(int4h mask, float4h v) {
+    return if_then_else16(mask, v, (float4h){0});
+}
+
+typedef struct {
+    float4h lo, hi;
+} iv16;
+
+static inline iv16 as_iv16(_Float16 x) {
+    return (iv16){
+        (float4h){x,x,x,x},
+        (float4h){x,x,x,x},
+    };
+}
+
+static inline iv16 iv16_add(iv16 x, iv16 y) {
+    return (iv16){
+        x.lo + y.lo,
+        x.hi + y.hi,
+    };
+}
+
+static inline iv16 iv16_sub(iv16 x, iv16 y) {
+    return (iv16){
+        x.lo - y.hi,
+        x.hi - y.lo,
+    };
+}
+
+static inline iv16 iv16_mul(iv16 x, iv16 y) {
+    float4h const a = x.lo * y.lo,
+                   b = x.hi * y.lo,
+                   c = x.lo * y.hi,
+                   d = x.hi * y.hi;
+    return (iv16){
+        __builtin_elementwise_min(__builtin_elementwise_min(a,b),
+                                  __builtin_elementwise_min(c,d)),
+        __builtin_elementwise_max(__builtin_elementwise_max(a,b),
+                                  __builtin_elementwise_max(c,d)),
+    };
+}
+
+static inline iv16 iv16_mad(iv16 x, iv16 y, iv16 z) {
+    return iv16_add(iv16_mul(x,y), z);
+}
+
+static inline iv16 iv16_min(iv16 x, iv16 y) {
+    return (iv16){
+        __builtin_elementwise_min(x.lo, y.lo),
+        __builtin_elementwise_min(x.hi, y.hi),
+    };
+}
+
+static inline iv16 iv16_max(iv16 x, iv16 y) {
+    return (iv16){
+        __builtin_elementwise_max(x.lo, y.lo),
+        __builtin_elementwise_max(x.hi, y.hi),
+    };
+}
+
+static inline iv16 iv16_sqrt(iv16 x) {
+    return (iv16){
+        __builtin_elementwise_sqrt(x.lo),
+        __builtin_elementwise_sqrt(x.hi),
+    };
+}
+
+static inline iv16 iv16_square(iv16 x) {
+    float4h const a2 = x.lo * x.lo,
+                   b2 = x.hi * x.hi;
+    return (iv16){
+        when16(x.lo > 0 | x.hi < 0,
+               __builtin_elementwise_min(a2,b2)),
+                                      __builtin_elementwise_max(a2,b2),
+    };
+}
+
+static inline iv16 iv16_abs(iv16 x) {
+    float4h const a = __builtin_elementwise_abs(x.lo),
+                   b = __builtin_elementwise_abs(x.hi);
+    return (iv16){
+        when16(x.lo > 0 | x.hi < 0,
+               __builtin_elementwise_min(a,b)),
+                                      __builtin_elementwise_max(a,b),
+    };
+}
+
+static inline iv16 iv16_inv(iv16 x) {
+    return (iv16){
+        if_then_else16(x.lo > 0 | x.hi < 0 | (x.lo >= 0 & x.hi > 0),
+                       1/x.hi, (float4h){0} - 1/0.0f),
+        if_then_else16(x.lo > 0 | x.hi < 0 | (x.lo < 0 & x.hi <= 0),
+                       1/x.lo, (float4h){0} + 1/0.0f),
     };
 }

--- a/iv.h
+++ b/iv.h
@@ -3,8 +3,8 @@
 typedef float __attribute__((vector_size(16))) float4;
 typedef   int __attribute__((vector_size(16)))   int4;
 
-typedef _Float16 __attribute__((vector_size(8))) float4h;
-typedef short    __attribute__((vector_size(8)))  int4h;
+typedef _Float16 __attribute__((vector_size(8))) half4;
+typedef short    __attribute__((vector_size(8))) short4;
 
 static inline float4 if_then_else(int4 mask, float4 t, float4 e) {
     return (float4)( ( mask & (int4)t)
@@ -98,23 +98,23 @@ static inline iv iv_inv(iv x) {
     };
 }
 
-static inline float4h if_then_else16(int4h mask, float4h t, float4h e) {
-    return (float4h)( (mask & (int4h)t)
-                    | (~mask & (int4h)e) );
+static inline half4 if_then_else16(short4 mask, half4 t, half4 e) {
+    return (half4)( ( mask & (short4)t)
+                  | (~mask & (short4)e) );
 }
 
-static inline float4h when16(int4h mask, float4h v) {
-    return if_then_else16(mask, v, (float4h){0});
+static inline half4 when16(short4 mask, half4 v) {
+    return if_then_else16(mask, v, (half4){0});
 }
 
 typedef struct {
-    float4h lo, hi;
+    half4 lo, hi;
 } iv16;
 
 static inline iv16 as_iv16(_Float16 x) {
     return (iv16){
-        (float4h){x,x,x,x},
-        (float4h){x,x,x,x},
+        (half4){x,x,x,x},
+        (half4){x,x,x,x},
     };
 }
 
@@ -133,10 +133,10 @@ static inline iv16 iv16_sub(iv16 x, iv16 y) {
 }
 
 static inline iv16 iv16_mul(iv16 x, iv16 y) {
-    float4h const a = x.lo * y.lo,
-                   b = x.hi * y.lo,
-                   c = x.lo * y.hi,
-                   d = x.hi * y.hi;
+    half4 const a = x.lo * y.lo,
+                 b = x.hi * y.lo,
+                 c = x.lo * y.hi,
+                 d = x.hi * y.hi;
     return (iv16){
         __builtin_elementwise_min(__builtin_elementwise_min(a,b),
                                   __builtin_elementwise_min(c,d)),
@@ -171,30 +171,28 @@ static inline iv16 iv16_sqrt(iv16 x) {
 }
 
 static inline iv16 iv16_square(iv16 x) {
-    float4h const a2 = x.lo * x.lo,
-                   b2 = x.hi * x.hi;
+    half4 const a2 = x.lo * x.lo,
+                 b2 = x.hi * x.hi;
     return (iv16){
-        when16(x.lo > 0 | x.hi < 0,
-               __builtin_elementwise_min(a2,b2)),
-                                      __builtin_elementwise_max(a2,b2),
+        when16(x.lo > 0 | x.hi < 0, __builtin_elementwise_min(a2,b2)),
+                                  __builtin_elementwise_max(a2,b2) ,
     };
 }
 
 static inline iv16 iv16_abs(iv16 x) {
-    float4h const a = __builtin_elementwise_abs(x.lo),
-                   b = __builtin_elementwise_abs(x.hi);
+    half4 const a = __builtin_elementwise_abs(x.lo),
+                 b = __builtin_elementwise_abs(x.hi);
     return (iv16){
-        when16(x.lo > 0 | x.hi < 0,
-               __builtin_elementwise_min(a,b)),
-                                      __builtin_elementwise_max(a,b),
+        when16(x.lo > 0 | x.hi < 0, __builtin_elementwise_min(a,b)),
+                                  __builtin_elementwise_max(a,b) ,
     };
 }
 
 static inline iv16 iv16_inv(iv16 x) {
     return (iv16){
         if_then_else16(x.lo > 0 | x.hi < 0 | (x.lo >= 0 & x.hi > 0),
-                       1/x.hi, (float4h){0} - 1/0.0f),
+                       1/x.hi, (half4){0} - 1/0.0f),
         if_then_else16(x.lo > 0 | x.hi < 0 | (x.lo < 0 & x.hi <= 0),
-                       1/x.lo, (float4h){0} + 1/0.0f),
+                       1/x.lo, (half4){0} + 1/0.0f),
     };
 }

--- a/iv.h
+++ b/iv.h
@@ -134,9 +134,9 @@ static inline iv16 iv16_sub(iv16 x, iv16 y) {
 
 static inline iv16 iv16_mul(iv16 x, iv16 y) {
     half4 const a = x.lo * y.lo,
-                 b = x.hi * y.lo,
-                 c = x.lo * y.hi,
-                 d = x.hi * y.hi;
+                b = x.hi * y.lo,
+                c = x.lo * y.hi,
+                d = x.hi * y.hi;
     return (iv16){
         __builtin_elementwise_min(__builtin_elementwise_min(a,b),
                                   __builtin_elementwise_min(c,d)),
@@ -172,27 +172,25 @@ static inline iv16 iv16_sqrt(iv16 x) {
 
 static inline iv16 iv16_square(iv16 x) {
     half4 const a2 = x.lo * x.lo,
-                 b2 = x.hi * x.hi;
+                b2 = x.hi * x.hi;
     return (iv16){
         when16(x.lo > 0 | x.hi < 0, __builtin_elementwise_min(a2,b2)),
-                                  __builtin_elementwise_max(a2,b2) ,
+                                    __builtin_elementwise_max(a2,b2) ,
     };
 }
 
 static inline iv16 iv16_abs(iv16 x) {
     half4 const a = __builtin_elementwise_abs(x.lo),
-                 b = __builtin_elementwise_abs(x.hi);
+                b = __builtin_elementwise_abs(x.hi);
     return (iv16){
         when16(x.lo > 0 | x.hi < 0, __builtin_elementwise_min(a,b)),
-                                  __builtin_elementwise_max(a,b) ,
+                                    __builtin_elementwise_max(a,b) ,
     };
 }
 
 static inline iv16 iv16_inv(iv16 x) {
     return (iv16){
-        if_then_else16(x.lo > 0 | x.hi < 0 | (x.lo >= 0 & x.hi > 0),
-                       1/x.hi, (half4){0} - 1/0.0f),
-        if_then_else16(x.lo > 0 | x.hi < 0 | (x.lo < 0 & x.hi <= 0),
-                       1/x.lo, (half4){0} + 1/0.0f),
+        if_then_else16(x.lo > 0 | x.hi < 0 | (x.lo >= 0 & x.hi > 0), 1/x.hi, (half4){0} - 1/0.0f),
+        if_then_else16(x.lo > 0 | x.hi < 0 | (x.lo < 0 & x.hi <= 0), 1/x.lo, (half4){0} + 1/0.0f),
     };
 }

--- a/iv_test.c
+++ b/iv_test.c
@@ -6,174 +6,24 @@ static void test_add(void) {
     expect(equiv(z.lo[0],  8));
     expect(equiv(z.hi[0], 10));
 }
-
 static void test_add16(void) {
     iv16 z = iv16_add((iv16){{3},{4}}, (iv16){{5},{6}});
     expect(equiv(z.lo[0],  8));
     expect(equiv(z.hi[0], 10));
 }
 
-static void test_sub16(void) {
-    iv16 z = iv16_sub((iv16){{3},{4}}, (iv16){{5},{6}});
-    expect(equiv(z.lo[0], -3));
-    expect(equiv(z.hi[0], -1));
-}
-
-static void test_mul16(void) {
-    iv16 z = iv16_mul((iv16){{3,-3,-3,-3},{4,4,4, 4}},
-                      (iv16){{5, 5,-5,-5},{6,6,6,-1}});
-    expect(equiv(z.lo[0],  15));
-    expect(equiv(z.hi[0],  24));
-
-    expect(equiv(z.lo[1], -18));
-    expect(equiv(z.hi[1],  24));
-
-    expect(equiv(z.lo[2], -20));
-    expect(equiv(z.hi[2],  24));
-
-    expect(equiv(z.lo[3], -20));
-    expect(equiv(z.hi[3],  15));
-}
-
-static void test_mad16(void) {
-    iv16 z = iv16_mad((iv16){{1,-1,-2,-1},{2,2,2,1}},
-                      (iv16){{2,-3,-1,0},{3,3,1,0}},
-                      (iv16){{1,1,0,0},{1,1,0,0}});
-    expect(equiv(z.lo[0],  3));
-    expect(equiv(z.hi[0],  7));
-
-    expect(equiv(z.lo[1], -5));
-    expect(equiv(z.hi[1],  7));
-
-    expect(equiv(z.lo[2], -2));
-    expect(equiv(z.hi[2],  2));
-
-    expect(equiv(z.lo[3],  0));
-    expect(equiv(z.hi[3],  0));
-}
-
-static void test_min16(void) {
-    iv16 z = iv16_min((iv16){{3,-3,-3},{4,4, 4}},
-                      (iv16){{5,-5,-5},{6,6,-1}});
-    expect(equiv(z.lo[0],  3));
-    expect(equiv(z.hi[0],  4));
-
-    expect(equiv(z.lo[1], -5));
-    expect(equiv(z.hi[1],  4));
-
-    expect(equiv(z.lo[2], -5));
-    expect(equiv(z.hi[2], -1));
-}
-
-static void test_max16(void) {
-    iv16 z = iv16_max((iv16){{3,-3,-3},{4,4, 4}},
-                      (iv16){{5,-5,-5},{6,6,-1}});
-    expect(equiv(z.lo[0],  5));
-    expect(equiv(z.hi[0],  6));
-
-    expect(equiv(z.lo[1], -3));
-    expect(equiv(z.hi[1],  6));
-
-    expect(equiv(z.lo[2], -3));
-    expect(equiv(z.hi[2],  4));
-}
-
-static void test_sqrt16(void) {
-    iv16 z = iv16_sqrt((iv16){{4},{16}});
-    expect(equiv(z.lo[0], 2));
-    expect(equiv(z.hi[0], 4));
-}
-
-static void test_square16(void) {
-    {
-        iv16 z = iv16_square((iv16){{3,-3,-5},{4,4,-1}});
-        expect(equiv(z.lo[0],  9));
-        expect(equiv(z.hi[0], 16));
-
-        expect(equiv(z.lo[1],  0));
-        expect(equiv(z.hi[1], 16));
-
-        expect(equiv(z.lo[2],  1));
-        expect(equiv(z.hi[2], 25));
-    }
-
-    {
-        iv16 z = iv16_square((iv16){{0,-2,0},{4,0,0}});
-        expect(equiv(z.lo[0],  0));
-        expect(equiv(z.hi[0], 16));
-
-        expect(equiv(z.lo[1],  0));
-        expect(equiv(z.hi[1],  4));
-
-        expect(equiv(z.lo[2],  0));
-        expect(equiv(z.hi[2],  0));
-    }
-}
-
-static void test_abs16(void) {
-    {
-        iv16 z = iv16_abs((iv16){{3,-3,-5},{4,4,-1}});
-        expect(equiv(z.lo[0], 3));
-        expect(equiv(z.hi[0], 4));
-
-        expect(equiv(z.lo[1], 0));
-        expect(equiv(z.hi[1], 4));
-
-        expect(equiv(z.lo[2], 1));
-        expect(equiv(z.hi[2], 5));
-    }
-
-    {
-        iv16 z = iv16_abs((iv16){{0,-2,0},{4,0,0}});
-        expect(equiv(z.lo[0], 0));
-        expect(equiv(z.hi[0], 4));
-
-        expect(equiv(z.lo[1], 0));
-        expect(equiv(z.hi[1], 2));
-
-        expect(equiv(z.lo[2], 0));
-        expect(equiv(z.hi[2], 0));
-    }
-}
-
-static void test_inv16(void) {
-    {
-        iv16 z = iv16_inv((iv16){{+1,-4,-1,+0},
-                                 {+4,-1,+4,+0}});
-        expect(equiv(z.lo[0], 0.25));
-        expect(equiv(z.hi[0], 1   ));
-
-        expect(equiv(z.lo[1], -1.00));
-        expect(equiv(z.hi[1], -0.25));
-
-        expect(equiv(z.lo[2], -1/0.0));
-        expect(equiv(z.hi[2], +1/0.0));
-
-        expect(equiv(z.lo[3], -1/0.0));
-        expect(equiv(z.hi[3], +1/0.0));
-    }
-    {
-        iv16 z = iv16_inv((iv16){{-0,-0,-1, 0},
-                                 {-0,+0, 0,+4}});
-        expect(equiv(z.lo[0], -1/0.0));
-        expect(equiv(z.hi[0], +1/0.0));
-
-        expect(equiv(z.lo[1], -1/0.0));
-        expect(equiv(z.hi[1], +1/0.0));
-
-        expect(equiv(z.lo[2], -1/0.0));
-        expect(equiv(z.hi[2], -1    ));
-
-        expect(equiv(z.lo[3],  0.25 ));
-        expect(equiv(z.hi[3], +1/0.0));
-    }
-}
 
 static void test_sub(void) {
     iv z = iv_sub((iv){{3},{4}}, (iv){{5},{6}});
     expect(equiv(z.lo[0], -3));
     expect(equiv(z.hi[0], -1));
 }
+static void test_sub16(void) {
+    iv16 z = iv16_sub((iv16){{3},{4}}, (iv16){{5},{6}});
+    expect(equiv(z.lo[0], -3));
+    expect(equiv(z.hi[0], -1));
+}
+
 
 static void test_mul(void) {
     iv z = iv_mul((iv){{3,-3,-3,-3},{4,4,4, 4}},
@@ -190,6 +40,22 @@ static void test_mul(void) {
     expect(equiv(z.lo[3], -20));
     expect(equiv(z.hi[3],  15));
 }
+static void test_mul16(void) {
+    iv16 z = iv16_mul((iv16){{3,-3,-3,-3},{4,4,4, 4}},
+                      (iv16){{5, 5,-5,-5},{6,6,6,-1}});
+    expect(equiv(z.lo[0],  15));
+    expect(equiv(z.hi[0],  24));
+
+    expect(equiv(z.lo[1], -18));
+    expect(equiv(z.hi[1],  24));
+
+    expect(equiv(z.lo[2], -20));
+    expect(equiv(z.hi[2],  24));
+
+    expect(equiv(z.lo[3], -20));
+    expect(equiv(z.hi[3],  15));
+}
+
 
 static void test_mad(void) {
     iv z = iv_mad((iv){{1,-1,-2,-1},{2,2,2,1}},
@@ -207,6 +73,23 @@ static void test_mad(void) {
     expect(equiv(z.lo[3],  0));
     expect(equiv(z.hi[3],  0));
 }
+static void test_mad16(void) {
+    iv16 z = iv16_mad((iv16){{1,-1,-2,-1},{2,2,2,1}},
+                      (iv16){{2,-3,-1,0},{3,3,1,0}},
+                      (iv16){{1,1,0,0},{1,1,0,0}});
+    expect(equiv(z.lo[0],  3));
+    expect(equiv(z.hi[0],  7));
+
+    expect(equiv(z.lo[1], -5));
+    expect(equiv(z.hi[1],  7));
+
+    expect(equiv(z.lo[2], -2));
+    expect(equiv(z.hi[2],  2));
+
+    expect(equiv(z.lo[3],  0));
+    expect(equiv(z.hi[3],  0));
+}
+
 
 static void test_min(void) {
     iv z = iv_min((iv){{3,-3,-3},{4,4, 4}},
@@ -220,6 +103,19 @@ static void test_min(void) {
     expect(equiv(z.lo[2], -5));
     expect(equiv(z.hi[2], -1));
 }
+static void test_min16(void) {
+    iv16 z = iv16_min((iv16){{3,-3,-3},{4,4, 4}},
+                      (iv16){{5,-5,-5},{6,6,-1}});
+    expect(equiv(z.lo[0],  3));
+    expect(equiv(z.hi[0],  4));
+
+    expect(equiv(z.lo[1], -5));
+    expect(equiv(z.hi[1],  4));
+
+    expect(equiv(z.lo[2], -5));
+    expect(equiv(z.hi[2], -1));
+}
+
 
 static void test_max(void) {
     iv z = iv_max((iv){{3,-3,-3},{4,4, 4}},
@@ -233,12 +129,31 @@ static void test_max(void) {
     expect(equiv(z.lo[2], -3));
     expect(equiv(z.hi[2],  4));
 }
+static void test_max16(void) {
+    iv16 z = iv16_max((iv16){{3,-3,-3},{4,4, 4}},
+                      (iv16){{5,-5,-5},{6,6,-1}});
+    expect(equiv(z.lo[0],  5));
+    expect(equiv(z.hi[0],  6));
+
+    expect(equiv(z.lo[1], -3));
+    expect(equiv(z.hi[1],  6));
+
+    expect(equiv(z.lo[2], -3));
+    expect(equiv(z.hi[2],  4));
+}
+
 
 static void test_sqrt(void) {
     iv z = iv_sqrt((iv){{4},{16}});
     expect(equiv(z.lo[0], 2));
     expect(equiv(z.hi[0], 4));
 }
+static void test_sqrt16(void) {
+    iv16 z = iv16_sqrt((iv16){{4},{16}});
+    expect(equiv(z.lo[0], 2));
+    expect(equiv(z.hi[0], 4));
+}
+
 
 static void test_square(void) {
     {
@@ -265,6 +180,32 @@ static void test_square(void) {
         expect(equiv(z.hi[2],  0));
     }
 }
+static void test_square16(void) {
+    {
+        iv16 z = iv16_square((iv16){{3,-3,-5},{4,4,-1}});
+        expect(equiv(z.lo[0],  9));
+        expect(equiv(z.hi[0], 16));
+
+        expect(equiv(z.lo[1],  0));
+        expect(equiv(z.hi[1], 16));
+
+        expect(equiv(z.lo[2],  1));
+        expect(equiv(z.hi[2], 25));
+    }
+
+    {
+        iv16 z = iv16_square((iv16){{0,-2,0},{4,0,0}});
+        expect(equiv(z.lo[0],  0));
+        expect(equiv(z.hi[0], 16));
+
+        expect(equiv(z.lo[1],  0));
+        expect(equiv(z.hi[1],  4));
+
+        expect(equiv(z.lo[2],  0));
+        expect(equiv(z.hi[2],  0));
+    }
+}
+
 
 static void test_abs(void) {
     {
@@ -291,6 +232,32 @@ static void test_abs(void) {
         expect(equiv(z.hi[2], 0));
     }
 }
+static void test_abs16(void) {
+    {
+        iv16 z = iv16_abs((iv16){{3,-3,-5},{4,4,-1}});
+        expect(equiv(z.lo[0], 3));
+        expect(equiv(z.hi[0], 4));
+
+        expect(equiv(z.lo[1], 0));
+        expect(equiv(z.hi[1], 4));
+
+        expect(equiv(z.lo[2], 1));
+        expect(equiv(z.hi[2], 5));
+    }
+
+    {
+        iv16 z = iv16_abs((iv16){{0,-2,0},{4,0,0}});
+        expect(equiv(z.lo[0], 0));
+        expect(equiv(z.hi[0], 4));
+
+        expect(equiv(z.lo[1], 0));
+        expect(equiv(z.hi[1], 2));
+
+        expect(equiv(z.lo[2], 0));
+        expect(equiv(z.hi[2], 0));
+    }
+}
+
 
 static void test_inv(void) {
     {
@@ -324,27 +291,50 @@ static void test_inv(void) {
         expect(equiv(z.hi[3], +1/0.0));
     }
 }
+static void test_inv16(void) {
+    {
+        iv16 z = iv16_inv((iv16){{+1,-4,-1,+0},
+                                 {+4,-1,+4,+0}});
+        expect(equiv(z.lo[0], 0.25));
+        expect(equiv(z.hi[0], 1   ));
+
+        expect(equiv(z.lo[1], -1.00));
+        expect(equiv(z.hi[1], -0.25));
+
+        expect(equiv(z.lo[2], -1/0.0));
+        expect(equiv(z.hi[2], +1/0.0));
+
+        expect(equiv(z.lo[3], -1/0.0));
+        expect(equiv(z.hi[3], +1/0.0));
+    }
+    {
+        iv16 z = iv16_inv((iv16){{-0,-0,-1, 0},
+                                 {-0,+0, 0,+4}});
+        expect(equiv(z.lo[0], -1/0.0));
+        expect(equiv(z.hi[0], +1/0.0));
+
+        expect(equiv(z.lo[1], -1/0.0));
+        expect(equiv(z.hi[1], +1/0.0));
+
+        expect(equiv(z.lo[2], -1/0.0));
+        expect(equiv(z.hi[2], -1    ));
+
+        expect(equiv(z.lo[3],  0.25 ));
+        expect(equiv(z.hi[3], +1/0.0));
+    }
+}
+
 
 int main(void) {
-    test_add16();
-    test_sub16();
-    test_mul16();
-    test_mad16();
-    test_min16();
-    test_max16();
-    test_sqrt16();
-    test_square16();
-    test_abs16();
-    test_inv16();
-    test_add();
-    test_sub();
-    test_mul();
-    test_mad();
-    test_min();
-    test_max();
-    test_sqrt();
-    test_square();
-    test_abs();
-    test_inv();
+    test_add();    test_add16();
+    test_sub();    test_sub16();
+    test_mul();    test_mul16();
+    test_mad();    test_mad16();
+    test_min();    test_min16();
+    test_max();    test_max16();
+    test_sqrt();   test_sqrt16();
+    test_square(); test_square16();
+    test_abs();    test_abs16();
+    test_inv();    test_inv16();
     return 0;
 }

--- a/iv_test.c
+++ b/iv_test.c
@@ -7,6 +7,168 @@ static void test_add(void) {
     expect(equiv(z.hi[0], 10));
 }
 
+static void test_add16(void) {
+    iv16 z = iv16_add((iv16){{3},{4}}, (iv16){{5},{6}});
+    expect(equiv(z.lo[0],  8));
+    expect(equiv(z.hi[0], 10));
+}
+
+static void test_sub16(void) {
+    iv16 z = iv16_sub((iv16){{3},{4}}, (iv16){{5},{6}});
+    expect(equiv(z.lo[0], -3));
+    expect(equiv(z.hi[0], -1));
+}
+
+static void test_mul16(void) {
+    iv16 z = iv16_mul((iv16){{3,-3,-3,-3},{4,4,4, 4}},
+                      (iv16){{5, 5,-5,-5},{6,6,6,-1}});
+    expect(equiv(z.lo[0],  15));
+    expect(equiv(z.hi[0],  24));
+
+    expect(equiv(z.lo[1], -18));
+    expect(equiv(z.hi[1],  24));
+
+    expect(equiv(z.lo[2], -20));
+    expect(equiv(z.hi[2],  24));
+
+    expect(equiv(z.lo[3], -20));
+    expect(equiv(z.hi[3],  15));
+}
+
+static void test_mad16(void) {
+    iv16 z = iv16_mad((iv16){{1,-1,-2,-1},{2,2,2,1}},
+                      (iv16){{2,-3,-1,0},{3,3,1,0}},
+                      (iv16){{1,1,0,0},{1,1,0,0}});
+    expect(equiv(z.lo[0],  3));
+    expect(equiv(z.hi[0],  7));
+
+    expect(equiv(z.lo[1], -5));
+    expect(equiv(z.hi[1],  7));
+
+    expect(equiv(z.lo[2], -2));
+    expect(equiv(z.hi[2],  2));
+
+    expect(equiv(z.lo[3],  0));
+    expect(equiv(z.hi[3],  0));
+}
+
+static void test_min16(void) {
+    iv16 z = iv16_min((iv16){{3,-3,-3},{4,4, 4}},
+                      (iv16){{5,-5,-5},{6,6,-1}});
+    expect(equiv(z.lo[0],  3));
+    expect(equiv(z.hi[0],  4));
+
+    expect(equiv(z.lo[1], -5));
+    expect(equiv(z.hi[1],  4));
+
+    expect(equiv(z.lo[2], -5));
+    expect(equiv(z.hi[2], -1));
+}
+
+static void test_max16(void) {
+    iv16 z = iv16_max((iv16){{3,-3,-3},{4,4, 4}},
+                      (iv16){{5,-5,-5},{6,6,-1}});
+    expect(equiv(z.lo[0],  5));
+    expect(equiv(z.hi[0],  6));
+
+    expect(equiv(z.lo[1], -3));
+    expect(equiv(z.hi[1],  6));
+
+    expect(equiv(z.lo[2], -3));
+    expect(equiv(z.hi[2],  4));
+}
+
+static void test_sqrt16(void) {
+    iv16 z = iv16_sqrt((iv16){{4},{16}});
+    expect(equiv(z.lo[0], 2));
+    expect(equiv(z.hi[0], 4));
+}
+
+static void test_square16(void) {
+    {
+        iv16 z = iv16_square((iv16){{3,-3,-5},{4,4,-1}});
+        expect(equiv(z.lo[0],  9));
+        expect(equiv(z.hi[0], 16));
+
+        expect(equiv(z.lo[1],  0));
+        expect(equiv(z.hi[1], 16));
+
+        expect(equiv(z.lo[2],  1));
+        expect(equiv(z.hi[2], 25));
+    }
+
+    {
+        iv16 z = iv16_square((iv16){{0,-2,0},{4,0,0}});
+        expect(equiv(z.lo[0],  0));
+        expect(equiv(z.hi[0], 16));
+
+        expect(equiv(z.lo[1],  0));
+        expect(equiv(z.hi[1],  4));
+
+        expect(equiv(z.lo[2],  0));
+        expect(equiv(z.hi[2],  0));
+    }
+}
+
+static void test_abs16(void) {
+    {
+        iv16 z = iv16_abs((iv16){{3,-3,-5},{4,4,-1}});
+        expect(equiv(z.lo[0], 3));
+        expect(equiv(z.hi[0], 4));
+
+        expect(equiv(z.lo[1], 0));
+        expect(equiv(z.hi[1], 4));
+
+        expect(equiv(z.lo[2], 1));
+        expect(equiv(z.hi[2], 5));
+    }
+
+    {
+        iv16 z = iv16_abs((iv16){{0,-2,0},{4,0,0}});
+        expect(equiv(z.lo[0], 0));
+        expect(equiv(z.hi[0], 4));
+
+        expect(equiv(z.lo[1], 0));
+        expect(equiv(z.hi[1], 2));
+
+        expect(equiv(z.lo[2], 0));
+        expect(equiv(z.hi[2], 0));
+    }
+}
+
+static void test_inv16(void) {
+    {
+        iv16 z = iv16_inv((iv16){{+1,-4,-1,+0},
+                                 {+4,-1,+4,+0}});
+        expect(equiv(z.lo[0], 0.25));
+        expect(equiv(z.hi[0], 1   ));
+
+        expect(equiv(z.lo[1], -1.00));
+        expect(equiv(z.hi[1], -0.25));
+
+        expect(equiv(z.lo[2], -1/0.0));
+        expect(equiv(z.hi[2], +1/0.0));
+
+        expect(equiv(z.lo[3], -1/0.0));
+        expect(equiv(z.hi[3], +1/0.0));
+    }
+    {
+        iv16 z = iv16_inv((iv16){{-0,-0,-1, 0},
+                                 {-0,+0, 0,+4}});
+        expect(equiv(z.lo[0], -1/0.0));
+        expect(equiv(z.hi[0], +1/0.0));
+
+        expect(equiv(z.lo[1], -1/0.0));
+        expect(equiv(z.hi[1], +1/0.0));
+
+        expect(equiv(z.lo[2], -1/0.0));
+        expect(equiv(z.hi[2], -1    ));
+
+        expect(equiv(z.lo[3],  0.25 ));
+        expect(equiv(z.hi[3], +1/0.0));
+    }
+}
+
 static void test_sub(void) {
     iv z = iv_sub((iv){{3},{4}}, (iv){{5},{6}});
     expect(equiv(z.lo[0], -3));
@@ -164,6 +326,16 @@ static void test_inv(void) {
 }
 
 int main(void) {
+    test_add16();
+    test_sub16();
+    test_mul16();
+    test_mad16();
+    test_min16();
+    test_max16();
+    test_sqrt16();
+    test_square16();
+    test_abs16();
+    test_inv16();
     test_add();
     test_sub();
     test_mul();

--- a/test.h
+++ b/test.h
@@ -4,7 +4,10 @@ int dprintf(int, char const*, ...);
 #define expect(x) if (!(x)) dprintf(2, "%s:%d %s expect(%s)\n", __FILE__, __LINE__, __func__, #x), \
                             __builtin_debugtrap()
 
-static inline _Bool equiv(float x, float y) {
-    return (x <= y && y <= x)
-        || (x != x && y != y);
+static inline __attribute__((overloadable)) _Bool equiv(float x, float y) {
+    return (x <= y && y <= x) || (x != x && y != y);
+}
+
+static inline __attribute__((overloadable)) _Bool equiv(_Float16 x, _Float16 y) {
+    return equiv((float)x, (float)y);
 }

--- a/test.h
+++ b/test.h
@@ -5,7 +5,8 @@ int dprintf(int, char const*, ...);
                             __builtin_debugtrap()
 
 static inline __attribute__((overloadable)) _Bool equiv(float x, float y) {
-    return (x <= y && y <= x) || (x != x && y != y);
+    return (x <= y && y <= x)
+        || (x != x && y != y);
 }
 
 static inline __attribute__((overloadable)) _Bool equiv(_Float16 x, _Float16 y) {


### PR DESCRIPTION
## Summary
- add `_Float16` vector definitions and `iv16` functions in `iv.h`
- overload `equiv` in `test.h` to support `_Float16`
- extend `iv_test.c` with `iv16` test coverage

## Testing
- `ninja -C . out/iv_test.ok`
- `ninja -C . out/iv2d_vm_test.ok out/iv2d_regions_test.ok`


------
https://chatgpt.com/codex/tasks/task_e_685330ac22548326aaf9be08d699b32b