### PR TITLE
Rename iv type to iv32

### DIFF
--- a/iv.h
+++ b/iv.h
@@ -17,82 +17,82 @@ static inline float4 when(int4 mask, float4 v) {
 
 typedef struct {
     float4 lo,hi;
-} iv;
+} iv32;
 
-static inline iv as_iv(float x) {
-    return (iv){{x,x,x,x}, {x,x,x,x}};
+static inline iv32 as_iv32(float x) {
+    return (iv32){{x,x,x,x}, {x,x,x,x}};
 }
 
-static inline iv iv_add(iv x, iv y) {
-    return (iv){
+static inline iv32 iv32_add(iv32 x, iv32 y) {
+    return (iv32){
         x.lo + y.lo,
         x.hi + y.hi,
     };
 }
 
-static inline iv iv_sub(iv x, iv y) {
-    return (iv){
+static inline iv32 iv32_sub(iv32 x, iv32 y) {
+    return (iv32){
         x.lo - y.hi,
         x.hi - y.lo,
     };
 }
 
-static inline iv iv_mul(iv x, iv y) {
+static inline iv32 iv32_mul(iv32 x, iv32 y) {
     float4 const a = x.lo * y.lo,
                  b = x.hi * y.lo,
                  c = x.lo * y.hi,
                  d = x.hi * y.hi;
-    return (iv){
+    return (iv32){
         __builtin_elementwise_min(__builtin_elementwise_min(a,b), __builtin_elementwise_min(c,d)),
         __builtin_elementwise_max(__builtin_elementwise_max(a,b), __builtin_elementwise_max(c,d)),
     };
 }
 
-static inline iv iv_mad(iv x, iv y, iv z) {
-    return iv_add(iv_mul(x,y), z);
+static inline iv32 iv32_mad(iv32 x, iv32 y, iv32 z) {
+    return iv32_add(iv32_mul(x,y), z);
 }
 
-static inline iv iv_min(iv x, iv y) {
-    return (iv){
+static inline iv32 iv32_min(iv32 x, iv32 y) {
+    return (iv32){
         __builtin_elementwise_min(x.lo, y.lo),
         __builtin_elementwise_min(x.hi, y.hi),
     };
 }
 
-static inline iv iv_max(iv x, iv y) {
-    return (iv){
+static inline iv32 iv32_max(iv32 x, iv32 y) {
+    return (iv32){
         __builtin_elementwise_max(x.lo, y.lo),
         __builtin_elementwise_max(x.hi, y.hi),
     };
 }
 
-static inline iv iv_sqrt(iv x) {
-    return (iv){
+static inline iv32 iv32_sqrt(iv32 x) {
+    return (iv32){
         __builtin_elementwise_sqrt(x.lo),
         __builtin_elementwise_sqrt(x.hi),
     };
 }
 
-static inline iv iv_square(iv x) {
+static inline iv32 iv32_square(iv32 x) {
     float4 const a2 = x.lo * x.lo,
                  b2 = x.hi * x.hi;
-    return (iv){
+    return (iv32){
         when(x.lo > 0 | x.hi < 0, __builtin_elementwise_min(a2,b2)),
                                   __builtin_elementwise_max(a2,b2) ,
     };
 }
 
-static inline iv iv_abs(iv x) {
+static inline iv32 iv32_abs(iv32 x) {
     float4 const a = __builtin_elementwise_abs(x.lo),
                  b = __builtin_elementwise_abs(x.hi);
-    return (iv){
+    return (iv32){
         when(x.lo > 0 | x.hi < 0, __builtin_elementwise_min(a,b)),
                                   __builtin_elementwise_max(a,b) ,
     };
 }
 
-static inline iv iv_inv(iv x) {
-    return (iv) {
+static inline iv32 iv32_inv(iv32 x) {
+    return (iv32) {
         if_then_else(x.lo > 0 | x.hi < 0 | (x.lo >= 0 & x.hi > 0), 1/x.hi, (float4){0} - 1/0.0f),
         if_then_else(x.lo > 0 | x.hi < 0 | (x.lo < 0 & x.hi <= 0), 1/x.lo, (float4){0} + 1/0.0f),
     };

--- a/iv2d.c
+++ b/iv2d.c
@@ -15,7 +15,7 @@ static float4 estimate_coverage_(struct iv2d_region const *region,
     float const x = (l+r)/2,
                 y = (t+b)/2;
     iv32 const corners = region->eval(region, (iv32){{l,l,x,x}, {x,x,r,r}}
-                                          , (iv32){{t,y,t,y}, {y,b,y,b}});
+                                            , (iv32){{t,y,t,y}, {y,b,y,b}});
     int4 inside, uncertain;
     classify(corners, &inside, &uncertain);
 
@@ -47,7 +47,7 @@ static void iv2d_cover_(struct iv2d_region const *region,
         float const x = floorf( (l+r)/2 ),
                     y = floorf( (t+b)/2 );
         iv32 const corners = region->eval(region, (iv32){{l,l,x,x}, {x,x,r,r}}
-                                              , (iv32){{t,y,t,y}, {y,b,y,b}});
+                                                , (iv32){{t,y,t,y}, {y,b,y,b}});
         int4 inside,uncertain;
         classify(corners, &inside, &uncertain);
 

--- a/iv2d.c
+++ b/iv2d.c
@@ -3,7 +3,7 @@
 
 // Our core idea: a signed distance function v=region(X,Y) is <= 0 inside the region
 // or >0 outside it.  When lo < 0 < hi, we're uncertain if we're inside or outside the region.
-static void classify(iv v, int4 *inside, int4 *uncertain) {
+static void classify(iv32 v, int4 *inside, int4 *uncertain) {
     *inside    = (v.hi <= 0);
     *uncertain = (v.lo <  0) & ~*inside;
 }
@@ -14,8 +14,8 @@ static float4 estimate_coverage_(struct iv2d_region const *region,
     // Evaluate LT, LB, RT, and RB corners of the region.
     float const x = (l+r)/2,
                 y = (t+b)/2;
-    iv const corners = region->eval(region, (iv){{l,l,x,x}, {x,x,r,r}}
-                                          , (iv){{t,y,t,y}, {y,b,y,b}});
+    iv32 const corners = region->eval(region, (iv32){{l,l,x,x}, {x,x,r,r}}
+                                          , (iv32){{t,y,t,y}, {y,b,y,b}});
     int4 inside, uncertain;
     classify(corners, &inside, &uncertain);
 
@@ -46,8 +46,8 @@ static void iv2d_cover_(struct iv2d_region const *region,
         // Evaluate LT, LB, RT, and RB corners of the region, split at integer pixels.
         float const x = floorf( (l+r)/2 ),
                     y = floorf( (t+b)/2 );
-        iv const corners = region->eval(region, (iv){{l,l,x,x}, {x,x,r,r}}
-                                              , (iv){{t,y,t,y}, {y,b,y,b}});
+        iv32 const corners = region->eval(region, (iv32){{l,l,x,x}, {x,x,r,r}}
+                                              , (iv32){{t,y,t,y}, {y,b,y,b}});
         int4 inside,uncertain;
         classify(corners, &inside, &uncertain);
 

--- a/iv2d.h
+++ b/iv2d.h
@@ -6,7 +6,7 @@
 // A 2D region represented as a signed distance function of x and y.
 // The boundary of the region is eval(x,y)==0, with eval(x,y)<=0 for area within the region.
 struct iv2d_region {
-    iv (*eval)(struct iv2d_region const*, iv x, iv y);
+    iv32 (*eval)(struct iv2d_region const*, iv32 x, iv32 y);
 };
 
 // iv2d_cover rasterizes an iv2d_region onto a bounded integer grid, yielding

--- a/iv2d_regions.c
+++ b/iv2d_regions.c
@@ -3,7 +3,7 @@
 iv32 iv2d_circle(struct iv2d_region const *region, iv32 x, iv32 y) {
     struct iv2d_circle const *c = (struct iv2d_circle const*)region;
     return iv32_sub(iv32_sqrt(iv32_add(iv32_square(iv32_sub(x, as_iv32(c->x))),
-                                 iv32_square(iv32_sub(y, as_iv32(c->y))))),
+                                       iv32_square(iv32_sub(y, as_iv32(c->y))))),
                   as_iv32(c->r));
 }
 
@@ -14,17 +14,17 @@ iv32 iv2d_capsule(struct iv2d_region const *region, iv32 x, iv32 y) {
                 dy = c->y1 - c->y0;
 
     iv32 const px = iv32_sub(x, as_iv32(c->x0)),
-             py = iv32_sub(y, as_iv32(c->y0));
+               py = iv32_sub(y, as_iv32(c->y0));
 
     iv32 const t = iv32_mul(iv32_add(iv32_mul(px, as_iv32(dx)),
-                               iv32_mul(py, as_iv32(dy))),
-                        as_iv32(1 / (dx*dx + dy*dy)));
+                                     iv32_mul(py, as_iv32(dy))),
+                            as_iv32(1 / (dx*dx + dy*dy)));
 
     iv32 const h = iv32_max(as_iv32(0), iv32_min(t, as_iv32(1)));
 
     return iv32_sub(iv32_sqrt(iv32_add(iv32_square(iv32_sub(px, iv32_mul(h, as_iv32(dx)))),
-                                 iv32_square(iv32_sub(py, iv32_mul(h, as_iv32(dy)))))),
-                  as_iv32(c->r));
+                                       iv32_square(iv32_sub(py, iv32_mul(h, as_iv32(dy)))))),
+                    as_iv32(c->r));
 }
 
 iv32 iv2d_union(struct iv2d_region const *region, iv32 x, iv32 y) {
@@ -58,6 +58,6 @@ iv32 iv2d_stroke(struct iv2d_region const *region, iv32 x, iv32 y) {
 iv32 iv2d_halfplane(struct iv2d_region const *region, iv32 x, iv32 y) {
     struct iv2d_halfplane const *hp = (struct iv2d_halfplane const*)region;
     return iv32_sub(iv32_add(iv32_mul(x, as_iv32(hp->nx)),
-                         iv32_mul(y, as_iv32(hp->ny))),
-                  as_iv32(hp->d));
+                             iv32_mul(y, as_iv32(hp->ny))),
+                    as_iv32(hp->d));
 }

--- a/iv2d_regions.c
+++ b/iv2d_regions.c
@@ -1,63 +1,63 @@
 #include "iv2d_regions.h"
 
-iv iv2d_circle(struct iv2d_region const *region, iv x, iv y) {
+iv32 iv2d_circle(struct iv2d_region const *region, iv32 x, iv32 y) {
     struct iv2d_circle const *c = (struct iv2d_circle const*)region;
-    return iv_sub(iv_sqrt(iv_add(iv_square(iv_sub(x, as_iv(c->x))),
-                                 iv_square(iv_sub(y, as_iv(c->y))))),
-                  as_iv(c->r));
+    return iv32_sub(iv32_sqrt(iv32_add(iv32_square(iv32_sub(x, as_iv32(c->x))),
+                                 iv32_square(iv32_sub(y, as_iv32(c->y))))),
+                  as_iv32(c->r));
 }
 
-iv iv2d_capsule(struct iv2d_region const *region, iv x, iv y) {
+iv32 iv2d_capsule(struct iv2d_region const *region, iv32 x, iv32 y) {
     struct iv2d_capsule const *c = (struct iv2d_capsule const*)region;
 
     float const dx = c->x1 - c->x0,
                 dy = c->y1 - c->y0;
 
-    iv const px = iv_sub(x, as_iv(c->x0)),
-             py = iv_sub(y, as_iv(c->y0));
+    iv32 const px = iv32_sub(x, as_iv32(c->x0)),
+             py = iv32_sub(y, as_iv32(c->y0));
 
-    iv const t = iv_mul(iv_add(iv_mul(px, as_iv(dx)),
-                               iv_mul(py, as_iv(dy))),
-                        as_iv(1 / (dx*dx + dy*dy)));
+    iv32 const t = iv32_mul(iv32_add(iv32_mul(px, as_iv32(dx)),
+                               iv32_mul(py, as_iv32(dy))),
+                        as_iv32(1 / (dx*dx + dy*dy)));
 
-    iv const h = iv_max(as_iv(0), iv_min(t, as_iv(1)));
+    iv32 const h = iv32_max(as_iv32(0), iv32_min(t, as_iv32(1)));
 
-    return iv_sub(iv_sqrt(iv_add(iv_square(iv_sub(px, iv_mul(h, as_iv(dx)))),
-                                 iv_square(iv_sub(py, iv_mul(h, as_iv(dy)))))),
-                  as_iv(c->r));
+    return iv32_sub(iv32_sqrt(iv32_add(iv32_square(iv32_sub(px, iv32_mul(h, as_iv32(dx)))),
+                                 iv32_square(iv32_sub(py, iv32_mul(h, as_iv32(dy)))))),
+                  as_iv32(c->r));
 }
 
-iv iv2d_union(struct iv2d_region const *region, iv x, iv y) {
+iv32 iv2d_union(struct iv2d_region const *region, iv32 x, iv32 y) {
     struct iv2d_setop const *c = (struct iv2d_setop const*)region;
-    iv v = as_iv(+1.0f/0);
+    iv32 v = as_iv32(+1.0f/0);
     for (int i = 0; i < c->subregions; i++) {
-        v = iv_min(v, c->subregion[i]->eval(c->subregion[i],x,y));
+        v = iv32_min(v, c->subregion[i]->eval(c->subregion[i],x,y));
     }
     return v;
 }
-iv iv2d_intersect(struct iv2d_region const *region, iv x, iv y) {
+iv32 iv2d_intersect(struct iv2d_region const *region, iv32 x, iv32 y) {
     struct iv2d_setop const *c = (struct iv2d_setop const*)region;
-    iv v = as_iv(-1.0f/0);
+    iv32 v = as_iv32(-1.0f/0);
     for (int i = 0; i < c->subregions; i++) {
-        v = iv_max(v, c->subregion[i]->eval(c->subregion[i],x,y));
+        v = iv32_max(v, c->subregion[i]->eval(c->subregion[i],x,y));
     }
     return v;
 }
 
-iv iv2d_invert(struct iv2d_region const *region, iv x, iv y) {
+iv32 iv2d_invert(struct iv2d_region const *region, iv32 x, iv32 y) {
     struct iv2d_invert const *c = (struct iv2d_invert const*)region;
-    return iv_sub(as_iv(0), c->arg->eval(c->arg,x,y));
+    return iv32_sub(as_iv32(0), c->arg->eval(c->arg,x,y));
 }
 
-iv iv2d_stroke(struct iv2d_region const *region, iv x, iv y) {
+iv32 iv2d_stroke(struct iv2d_region const *region, iv32 x, iv32 y) {
     struct iv2d_stroke const *stroke = (struct iv2d_stroke const*)region;
-    return iv_sub(iv_abs(stroke->arg->eval(stroke->arg,x,y)),
-                  as_iv(stroke->width));
+    return iv32_sub(iv32_abs(stroke->arg->eval(stroke->arg,x,y)),
+                  as_iv32(stroke->width));
 }
 
-iv iv2d_halfplane(struct iv2d_region const *region, iv x, iv y) {
+iv32 iv2d_halfplane(struct iv2d_region const *region, iv32 x, iv32 y) {
     struct iv2d_halfplane const *hp = (struct iv2d_halfplane const*)region;
-    return iv_sub(iv_add(iv_mul(x, as_iv(hp->nx)),
-                         iv_mul(y, as_iv(hp->ny))),
-                  as_iv(hp->d));
+    return iv32_sub(iv32_add(iv32_mul(x, as_iv32(hp->nx)),
+                         iv32_mul(y, as_iv32(hp->ny))),
+                  as_iv32(hp->d));
 }

--- a/iv2d_regions.h
+++ b/iv2d_regions.h
@@ -6,37 +6,37 @@ struct iv2d_circle {
     struct iv2d_region region;
     float              x,y,r, padding;
 };
-iv iv2d_circle(struct iv2d_region const*, iv x, iv y);
+iv32 iv2d_circle(struct iv2d_region const*, iv32 x, iv32 y);
 
 struct iv2d_capsule {
     struct iv2d_region region;
     float              x0,y0,x1,y1,r, padding;
 };
-iv iv2d_capsule(struct iv2d_region const*, iv x, iv y);
+iv32 iv2d_capsule(struct iv2d_region const*, iv32 x, iv32 y);
 
 struct iv2d_setop {
     struct iv2d_region         region;
     struct iv2d_region const **subregion;
     int                        subregions, padding;
 };
-iv iv2d_union    (struct iv2d_region const*, iv x, iv y);
-iv iv2d_intersect(struct iv2d_region const*, iv x, iv y);
+iv32 iv2d_union    (struct iv2d_region const*, iv32 x, iv32 y);
+iv32 iv2d_intersect(struct iv2d_region const*, iv32 x, iv32 y);
 
 struct iv2d_invert {
     struct iv2d_region        region;
     struct iv2d_region const *arg;
 };
-iv iv2d_invert(struct iv2d_region const*, iv x, iv y);
+iv32 iv2d_invert(struct iv2d_region const*, iv32 x, iv32 y);
 
 struct iv2d_stroke {
     struct iv2d_region        region;
     struct iv2d_region const *arg;
     float                     width, padding;
 };
-iv iv2d_stroke(struct iv2d_region const*, iv x, iv y);
+iv32 iv2d_stroke(struct iv2d_region const*, iv32 x, iv32 y);
 
 struct iv2d_halfplane {
     struct iv2d_region region;
     float              nx,ny,d, padding;
 };
-iv iv2d_halfplane(struct iv2d_region const*, iv x, iv y);
+iv32 iv2d_halfplane(struct iv2d_region const*, iv32 x, iv32 y);

--- a/iv2d_regions_test.c
+++ b/iv2d_regions_test.c
@@ -16,11 +16,11 @@ static void record(void *arg, float l,float t,float r,float b,float cov) {
 static void test_circle(void) {
     struct iv2d_circle c = {.region={iv2d_circle}, 0,0,1};
 
-    iv v = c.region.eval(&c.region, as_iv(0), as_iv(0));
+    iv32 v = c.region.eval(&c.region, as_iv32(0), as_iv32(0));
     expect(equiv(v.lo[0], -1));
     expect(equiv(v.hi[0], -1));
 
-    v = c.region.eval(&c.region, as_iv(1.5f), as_iv(0));
+    v = c.region.eval(&c.region, as_iv32(1.5f), as_iv32(0));
     expect(equiv(v.lo[0], 0.5f));
     expect(equiv(v.hi[0], 0.5f));
 }
@@ -31,11 +31,11 @@ static void test_union(void) {
     struct iv2d_region const *subs[] = {&a.region,&b.region};
     struct iv2d_setop u = {.region={iv2d_union}, subs, 2};
 
-    iv v = u.region.eval(&u.region, as_iv(0), as_iv(0));
+    iv32 v = u.region.eval(&u.region, as_iv32(0), as_iv32(0));
     expect(equiv(v.lo[0], -1));
     expect(equiv(v.hi[0], -1));
 
-    v = u.region.eval(&u.region, as_iv(1.5f), as_iv(0));
+    v = u.region.eval(&u.region, as_iv32(1.5f), as_iv32(0));
     expect(equiv(v.lo[0], -0.5f));
     expect(equiv(v.hi[0], -0.5f));
 }

--- a/iv2d_vm.c
+++ b/iv2d_vm.c
@@ -58,37 +58,37 @@ struct program {
     struct inst inst[];
 };
 
-static iv run_program(struct iv2d_region const *region, iv x, iv y) {
+static iv32 run_program(struct iv2d_region const *region, iv32 x, iv32 y) {
     struct program const *p = (struct program const*)region;
 
     _Thread_local static struct program const *active_program;
-    _Thread_local static iv *v;
+    _Thread_local static iv32 *v;
     if (active_program != p) {
         active_program  = p;
         v = realloc(v, (size_t)p->vals * sizeof *v);
         for (int i = 0; i < p->imms; i++) {
-            v[i] = as_iv(p->inst[i].imm);
+            v[i] = as_iv32(p->inst[i].imm);
         }
     }
 
-    iv *next = v+p->imms;
+    iv32 *next = v+p->imms;
     for (struct inst const *inst = p->inst+p->imms; ; inst++) {
         #pragma clang diagnostic ignored "-Wswitch-default"
         switch (inst->op) {
             case IMM: __builtin_unreachable();
 
-            case UNI: *next++ = as_iv(*inst->ptr);                  break;
+            case UNI: *next++ = as_iv32(*inst->ptr);                  break;
             case X:   *next++ = x;                                  break;
             case Y:   *next++ = y;                                  break;
-            case ABS: *next++ = iv_abs   (           v[inst->rhs]); break;
-            case SQT: *next++ = iv_sqrt  (           v[inst->rhs]); break;
-            case SQR: *next++ = iv_square(           v[inst->rhs]); break;
-            case INV: *next++ = iv_inv   (           v[inst->rhs]); break;
-            case ADD: *next++ = iv_add(v[inst->lhs], v[inst->rhs]); break;
-            case SUB: *next++ = iv_sub(v[inst->lhs], v[inst->rhs]); break;
-            case MUL: *next++ = iv_mul(v[inst->lhs], v[inst->rhs]); break;
-            case MIN: *next++ = iv_min(v[inst->lhs], v[inst->rhs]); break;
-            case MAX: *next++ = iv_max(v[inst->lhs], v[inst->rhs]); break;
+            case ABS: *next++ = iv32_abs   (           v[inst->rhs]); break;
+            case SQT: *next++ = iv32_sqrt  (           v[inst->rhs]); break;
+            case SQR: *next++ = iv32_square(           v[inst->rhs]); break;
+            case INV: *next++ = iv32_inv   (           v[inst->rhs]); break;
+            case ADD: *next++ = iv32_add(v[inst->lhs], v[inst->rhs]); break;
+            case SUB: *next++ = iv32_sub(v[inst->lhs], v[inst->rhs]); break;
+            case MUL: *next++ = iv32_mul(v[inst->lhs], v[inst->rhs]); break;
+            case MIN: *next++ = iv32_min(v[inst->lhs], v[inst->rhs]); break;
+            case MAX: *next++ = iv32_max(v[inst->lhs], v[inst->rhs]); break;
 
             case RET: return v[inst->rhs];
         }

--- a/iv2d_vm.c
+++ b/iv2d_vm.c
@@ -78,8 +78,8 @@ static iv32 run_program(struct iv2d_region const *region, iv32 x, iv32 y) {
             case IMM: __builtin_unreachable();
 
             case UNI: *next++ = as_iv32(*inst->ptr);                  break;
-            case X:   *next++ = x;                                  break;
-            case Y:   *next++ = y;                                  break;
+            case X:   *next++ = x;                                    break;
+            case Y:   *next++ = y;                                    break;
             case ABS: *next++ = iv32_abs   (           v[inst->rhs]); break;
             case SQT: *next++ = iv32_sqrt  (           v[inst->rhs]); break;
             case SQR: *next++ = iv32_square(           v[inst->rhs]); break;

--- a/iv2d_vm_test.c
+++ b/iv2d_vm_test.c
@@ -14,7 +14,7 @@ static void test_sub(void) {
     }
 
     iv32 x = (iv32){{0,1,2,3}, {4,5,6,7}},
-       y = (iv32){{0,0,1,1}, {5,4,3,2}};
+         y = (iv32){{0,0,1,1}, {5,4,3,2}};
     iv32 z = region->eval(region, x,y);
     iv32 e = iv32_sub(x,y);
     for (int i = 0; i < 4; i++) {
@@ -34,7 +34,7 @@ static void test_add(void) {
     }
 
     iv32 x = (iv32){{1,2,3,4}, {5,6,7,8}},
-       y = (iv32){{8,7,6,5}, {4,3,2,1}};
+         y = (iv32){{8,7,6,5}, {4,3,2,1}};
     iv32 z = region->eval(region, x,y);
     iv32 e = iv32_add(x,y);
     for (int i = 0; i < 4; i++) {
@@ -54,7 +54,7 @@ static void test_mul(void) {
     }
 
     iv32 x = (iv32){{3,-3,-3,-3}, {4,4,4,4}},
-       y = (iv32){{5,5,-5,-5}, {6,6,6,-1}};
+         y = (iv32){{5,5,-5,-5}, {6,6,6,-1}};
     iv32 z = region->eval(region, x,y);
     iv32 e = iv32_mul(x,y);
     for (int i = 0; i < 4; i++) {
@@ -74,7 +74,7 @@ static void test_min(void) {
     }
 
     iv32 x = (iv32){{3,-3,-3}, {4,4,4}},
-       y = (iv32){{5,-5,-5}, {6,6,-1}};
+         y = (iv32){{5,-5,-5}, {6,6,-1}};
     iv32 z = region->eval(region, x,y);
     iv32 e = iv32_min(x,y);
     for (int i = 0; i < 3; i++) {
@@ -94,7 +94,7 @@ static void test_max(void) {
     }
 
     iv32 x = (iv32){{3,-3,-3}, {4,4,4}},
-       y = (iv32){{5,-5,-5}, {6,6,-1}};
+         y = (iv32){{5,-5,-5}, {6,6,-1}};
     iv32 z = region->eval(region, x,y);
     iv32 e = iv32_max(x,y);
     for (int i = 0; i < 3; i++) {
@@ -185,7 +185,7 @@ static void test_mad_imm_uni(void) {
     }
 
     iv32 x = (iv32){{1,2,3,4}, {5,6,7,8}},
-       y = (iv32){{8,7,6,5}, {4,3,2,1}};
+         y = (iv32){{8,7,6,5}, {4,3,2,1}};
 
     iv32 z = region->eval(region, x,y);
     iv32 e = iv32_mad(x,y,as_iv32(3));

--- a/iv2d_vm_test.c
+++ b/iv2d_vm_test.c
@@ -13,10 +13,10 @@ static void test_sub(void) {
         region = iv2d_ret(b, iv2d_sub(b,x,y));
     }
 
-    iv x = (iv){{0,1,2,3}, {4,5,6,7}},
-       y = (iv){{0,0,1,1}, {5,4,3,2}};
-    iv z = region->eval(region, x,y);
-    iv e = iv_sub(x,y);
+    iv32 x = (iv32){{0,1,2,3}, {4,5,6,7}},
+       y = (iv32){{0,0,1,1}, {5,4,3,2}};
+    iv32 z = region->eval(region, x,y);
+    iv32 e = iv32_sub(x,y);
     for (int i = 0; i < 4; i++) {
         expect(equiv(z.lo[i], e.lo[i]));
         expect(equiv(z.hi[i], e.hi[i]));
@@ -33,10 +33,10 @@ static void test_add(void) {
         region = iv2d_ret(b, iv2d_add(b,x,y));
     }
 
-    iv x = (iv){{1,2,3,4}, {5,6,7,8}},
-       y = (iv){{8,7,6,5}, {4,3,2,1}};
-    iv z = region->eval(region, x,y);
-    iv e = iv_add(x,y);
+    iv32 x = (iv32){{1,2,3,4}, {5,6,7,8}},
+       y = (iv32){{8,7,6,5}, {4,3,2,1}};
+    iv32 z = region->eval(region, x,y);
+    iv32 e = iv32_add(x,y);
     for (int i = 0; i < 4; i++) {
         expect(equiv(z.lo[i], e.lo[i]));
         expect(equiv(z.hi[i], e.hi[i]));
@@ -53,10 +53,10 @@ static void test_mul(void) {
         region = iv2d_ret(b, iv2d_mul(b,x,y));
     }
 
-    iv x = (iv){{3,-3,-3,-3}, {4,4,4,4}},
-       y = (iv){{5,5,-5,-5}, {6,6,6,-1}};
-    iv z = region->eval(region, x,y);
-    iv e = iv_mul(x,y);
+    iv32 x = (iv32){{3,-3,-3,-3}, {4,4,4,4}},
+       y = (iv32){{5,5,-5,-5}, {6,6,6,-1}};
+    iv32 z = region->eval(region, x,y);
+    iv32 e = iv32_mul(x,y);
     for (int i = 0; i < 4; i++) {
         expect(equiv(z.lo[i], e.lo[i]));
         expect(equiv(z.hi[i], e.hi[i]));
@@ -73,10 +73,10 @@ static void test_min(void) {
         region = iv2d_ret(b, iv2d_min(b,x,y));
     }
 
-    iv x = (iv){{3,-3,-3}, {4,4,4}},
-       y = (iv){{5,-5,-5}, {6,6,-1}};
-    iv z = region->eval(region, x,y);
-    iv e = iv_min(x,y);
+    iv32 x = (iv32){{3,-3,-3}, {4,4,4}},
+       y = (iv32){{5,-5,-5}, {6,6,-1}};
+    iv32 z = region->eval(region, x,y);
+    iv32 e = iv32_min(x,y);
     for (int i = 0; i < 3; i++) {
         expect(equiv(z.lo[i], e.lo[i]));
         expect(equiv(z.hi[i], e.hi[i]));
@@ -93,10 +93,10 @@ static void test_max(void) {
         region = iv2d_ret(b, iv2d_max(b,x,y));
     }
 
-    iv x = (iv){{3,-3,-3}, {4,4,4}},
-       y = (iv){{5,-5,-5}, {6,6,-1}};
-    iv z = region->eval(region, x,y);
-    iv e = iv_max(x,y);
+    iv32 x = (iv32){{3,-3,-3}, {4,4,4}},
+       y = (iv32){{5,-5,-5}, {6,6,-1}};
+    iv32 z = region->eval(region, x,y);
+    iv32 e = iv32_max(x,y);
     for (int i = 0; i < 3; i++) {
         expect(equiv(z.lo[i], e.lo[i]));
         expect(equiv(z.hi[i], e.hi[i]));
@@ -112,8 +112,8 @@ static void test_sqrt(void) {
         region = iv2d_ret(b, iv2d_sqrt(b,v));
     }
 
-    iv z = region->eval(region, as_iv(0), as_iv(0));
-    iv e = iv_sqrt(as_iv(4));
+    iv32 z = region->eval(region, as_iv32(0), as_iv32(0));
+    iv32 e = iv32_sqrt(as_iv32(4));
     expect(equiv(z.lo[0], e.lo[0]));
     expect(equiv(z.hi[0], e.hi[0]));
 }
@@ -127,9 +127,9 @@ static void test_square(void) {
         region = iv2d_ret(b, iv2d_square(b,x));
     }
 
-    iv x = (iv){{3,-3,-5}, {4,4,-1}};
-    iv z = region->eval(region, x, as_iv(0));
-    iv e = iv_square(x);
+    iv32 x = (iv32){{3,-3,-5}, {4,4,-1}};
+    iv32 z = region->eval(region, x, as_iv32(0));
+    iv32 e = iv32_square(x);
     for (int i = 0; i < 3; i++) {
         expect(equiv(z.lo[i], e.lo[i]));
         expect(equiv(z.hi[i], e.hi[i]));
@@ -145,9 +145,9 @@ static void test_abs(void) {
         region = iv2d_ret(b, iv2d_abs(b,x));
     }
 
-    iv x = (iv){{0,-2,0}, {4,0,0}};
-    iv z = region->eval(region, x, as_iv(0));
-    iv e = iv_abs(x);
+    iv32 x = (iv32){{0,-2,0}, {4,0,0}};
+    iv32 z = region->eval(region, x, as_iv32(0));
+    iv32 e = iv32_abs(x);
     for (int i = 0; i < 3; i++) {
         expect(equiv(z.lo[i], e.lo[i]));
         expect(equiv(z.hi[i], e.hi[i]));
@@ -163,9 +163,9 @@ static void test_inv(void) {
         region = iv2d_ret(b, iv2d_inv(b,x));
     }
 
-    iv x = (iv){{+1,-4,-1,+0}, {+4,-1,+4,+0}};
-    iv z = region->eval(region, x, as_iv(0));
-    iv e = iv_inv(x);
+    iv32 x = (iv32){{+1,-4,-1,+0}, {+4,-1,+4,+0}};
+    iv32 z = region->eval(region, x, as_iv32(0));
+    iv32 e = iv32_inv(x);
     for (int i = 0; i < 4; i++) {
         expect(equiv(z.lo[i], e.lo[i]));
         expect(equiv(z.hi[i], e.hi[i]));
@@ -184,11 +184,11 @@ static void test_mad_imm_uni(void) {
         region = iv2d_ret(b, iv2d_mad(b,x,y,c));
     }
 
-    iv x = (iv){{1,2,3,4}, {5,6,7,8}},
-       y = (iv){{8,7,6,5}, {4,3,2,1}};
+    iv32 x = (iv32){{1,2,3,4}, {5,6,7,8}},
+       y = (iv32){{8,7,6,5}, {4,3,2,1}};
 
-    iv z = region->eval(region, x,y);
-    iv e = iv_mad(x,y,as_iv(3));
+    iv32 z = region->eval(region, x,y);
+    iv32 e = iv32_mad(x,y,as_iv32(3));
     for (int i = 0; i < 4; i++) {
         expect(equiv(z.lo[i], e.lo[i]));
         expect(equiv(z.hi[i], e.hi[i]));
@@ -196,7 +196,7 @@ static void test_mad_imm_uni(void) {
 
     u = 4;
     z = region->eval(region, x,y);
-    e = iv_mad(x,y,as_iv(4));
+    e = iv32_mad(x,y,as_iv32(4));
     for (int i = 0; i < 4; i++) {
         expect(equiv(z.lo[i], e.lo[i]));
         expect(equiv(z.hi[i], e.hi[i]));

--- a/iv_test.c
+++ b/iv_test.c
@@ -27,7 +27,7 @@ static void test_sub16(void) {
 
 static void test_mul(void) {
     iv32 z = iv32_mul((iv32){{3,-3,-3,-3},{4,4,4, 4}},
-                  (iv32){{5, 5,-5,-5},{6,6,6,-1}});
+                      (iv32){{5, 5,-5,-5},{6,6,6,-1}});
     expect(equiv(z.lo[0],  15));
     expect(equiv(z.hi[0],  24));
 
@@ -59,8 +59,8 @@ static void test_mul16(void) {
 
 static void test_mad(void) {
     iv32 z = iv32_mad((iv32){{1,-1,-2,-1},{2,2,2,1}},
-                  (iv32){{2,-3,-1,0},{3,3,1,0}},
-                  (iv32){{1,1,0,0},{1,1,0,0}});
+                      (iv32){{2,-3,-1,0},{3,3,1,0}},
+                      (iv32){{1,1,0,0},{1,1,0,0}});
     expect(equiv(z.lo[0],  3));
     expect(equiv(z.hi[0],  7));
 
@@ -93,7 +93,7 @@ static void test_mad16(void) {
 
 static void test_min(void) {
     iv32 z = iv32_min((iv32){{3,-3,-3},{4,4, 4}},
-                  (iv32){{5,-5,-5},{6,6,-1}});
+                      (iv32){{5,-5,-5},{6,6,-1}});
     expect(equiv(z.lo[0],  3));
     expect(equiv(z.hi[0],  4));
 
@@ -119,7 +119,7 @@ static void test_min16(void) {
 
 static void test_max(void) {
     iv32 z = iv32_max((iv32){{3,-3,-3},{4,4, 4}},
-                  (iv32){{5,-5,-5},{6,6,-1}});
+                      (iv32){{5,-5,-5},{6,6,-1}});
     expect(equiv(z.lo[0],  5));
     expect(equiv(z.hi[0],  6));
 
@@ -262,7 +262,7 @@ static void test_abs16(void) {
 static void test_inv(void) {
     {
         iv32 z = iv32_inv((iv32){{+1,-4,-1,+0},
-                           {+4,-1,+4,+0}});
+                                 {+4,-1,+4,+0}});
         expect(equiv(z.lo[0], 0.25));
         expect(equiv(z.hi[0], 1   ));
 
@@ -277,7 +277,7 @@ static void test_inv(void) {
     }
     {
         iv32 z = iv32_inv((iv32){{-0,-0,-1, 0},
-                           {-0,+0, 0,+4}});
+                                 {-0,+0, 0,+4}});
         expect(equiv(z.lo[0], -1/0.0));
         expect(equiv(z.hi[0], +1/0.0));
 

--- a/iv_test.c
+++ b/iv_test.c
@@ -2,7 +2,7 @@
 #include "test.h"
 
 static void test_add(void) {
-    iv z = iv_add((iv){{3},{4}}, (iv){{5},{6}});
+    iv32 z = iv32_add((iv32){{3},{4}}, (iv32){{5},{6}});
     expect(equiv(z.lo[0],  8));
     expect(equiv(z.hi[0], 10));
 }
@@ -14,7 +14,7 @@ static void test_add16(void) {
 
 
 static void test_sub(void) {
-    iv z = iv_sub((iv){{3},{4}}, (iv){{5},{6}});
+    iv32 z = iv32_sub((iv32){{3},{4}}, (iv32){{5},{6}});
     expect(equiv(z.lo[0], -3));
     expect(equiv(z.hi[0], -1));
 }
@@ -26,8 +26,8 @@ static void test_sub16(void) {
 
 
 static void test_mul(void) {
-    iv z = iv_mul((iv){{3,-3,-3,-3},{4,4,4, 4}},
-                  (iv){{5, 5,-5,-5},{6,6,6,-1}});
+    iv32 z = iv32_mul((iv32){{3,-3,-3,-3},{4,4,4, 4}},
+                  (iv32){{5, 5,-5,-5},{6,6,6,-1}});
     expect(equiv(z.lo[0],  15));
     expect(equiv(z.hi[0],  24));
 
@@ -58,9 +58,9 @@ static void test_mul16(void) {
 
 
 static void test_mad(void) {
-    iv z = iv_mad((iv){{1,-1,-2,-1},{2,2,2,1}},
-                  (iv){{2,-3,-1,0},{3,3,1,0}},
-                  (iv){{1,1,0,0},{1,1,0,0}});
+    iv32 z = iv32_mad((iv32){{1,-1,-2,-1},{2,2,2,1}},
+                  (iv32){{2,-3,-1,0},{3,3,1,0}},
+                  (iv32){{1,1,0,0},{1,1,0,0}});
     expect(equiv(z.lo[0],  3));
     expect(equiv(z.hi[0],  7));
 
@@ -92,8 +92,8 @@ static void test_mad16(void) {
 
 
 static void test_min(void) {
-    iv z = iv_min((iv){{3,-3,-3},{4,4, 4}},
-                  (iv){{5,-5,-5},{6,6,-1}});
+    iv32 z = iv32_min((iv32){{3,-3,-3},{4,4, 4}},
+                  (iv32){{5,-5,-5},{6,6,-1}});
     expect(equiv(z.lo[0],  3));
     expect(equiv(z.hi[0],  4));
 
@@ -118,8 +118,8 @@ static void test_min16(void) {
 
 
 static void test_max(void) {
-    iv z = iv_max((iv){{3,-3,-3},{4,4, 4}},
-                  (iv){{5,-5,-5},{6,6,-1}});
+    iv32 z = iv32_max((iv32){{3,-3,-3},{4,4, 4}},
+                  (iv32){{5,-5,-5},{6,6,-1}});
     expect(equiv(z.lo[0],  5));
     expect(equiv(z.hi[0],  6));
 
@@ -144,7 +144,7 @@ static void test_max16(void) {
 
 
 static void test_sqrt(void) {
-    iv z = iv_sqrt((iv){{4},{16}});
+    iv32 z = iv32_sqrt((iv32){{4},{16}});
     expect(equiv(z.lo[0], 2));
     expect(equiv(z.hi[0], 4));
 }
@@ -157,7 +157,7 @@ static void test_sqrt16(void) {
 
 static void test_square(void) {
     {
-        iv z = iv_square((iv){{3,-3,-5},{4,4,-1}});
+        iv32 z = iv32_square((iv32){{3,-3,-5},{4,4,-1}});
         expect(equiv(z.lo[0],  9));
         expect(equiv(z.hi[0], 16));
 
@@ -169,7 +169,7 @@ static void test_square(void) {
     }
 
     {
-        iv z = iv_square((iv){{0,-2,0},{4,0,0}});
+        iv32 z = iv32_square((iv32){{0,-2,0},{4,0,0}});
         expect(equiv(z.lo[0],  0));
         expect(equiv(z.hi[0], 16));
 
@@ -209,7 +209,7 @@ static void test_square16(void) {
 
 static void test_abs(void) {
     {
-        iv z = iv_abs((iv){{3,-3,-5},{4,4,-1}});
+        iv32 z = iv32_abs((iv32){{3,-3,-5},{4,4,-1}});
         expect(equiv(z.lo[0], 3));
         expect(equiv(z.hi[0], 4));
 
@@ -221,7 +221,7 @@ static void test_abs(void) {
     }
 
     {
-        iv z = iv_abs((iv){{0,-2,0},{4,0,0}});
+        iv32 z = iv32_abs((iv32){{0,-2,0},{4,0,0}});
         expect(equiv(z.lo[0], 0));
         expect(equiv(z.hi[0], 4));
 
@@ -261,7 +261,7 @@ static void test_abs16(void) {
 
 static void test_inv(void) {
     {
-        iv z = iv_inv((iv){{+1,-4,-1,+0},
+        iv32 z = iv32_inv((iv32){{+1,-4,-1,+0},
                            {+4,-1,+4,+0}});
         expect(equiv(z.lo[0], 0.25));
         expect(equiv(z.hi[0], 1   ));
@@ -276,7 +276,7 @@ static void test_inv(void) {
         expect(equiv(z.hi[3], +1/0.0));
     }
     {
-        iv z = iv_inv((iv){{-0,-0,-1, 0},
+        iv32 z = iv32_inv((iv32){{-0,-0,-1, 0},
                            {-0,+0, 0,+4}});
         expect(equiv(z.lo[0], -1/0.0));
         expect(equiv(z.hi[0], +1/0.0));


### PR DESCRIPTION
## Summary
- rename floating interval type to `iv32`
- update all functions and tests for `iv32`

## Testing
- `ninja`
- `ninja -f dbg` *(fails: AddressSanitizer leaks)*

------
https://chatgpt.com/codex/tasks/task_e_68533b2dbc6483269f0e92b9ea708bb1