### PR TITLE
Improve iv2d region helper readability

### DIFF
--- a/iv2d_regions.c
+++ b/iv2d_regions.c
@@ -2,9 +2,14 @@
 
 iv32 iv2d_circle(struct iv2d_region const *region, iv32 x, iv32 y) {
     struct iv2d_circle const *c = (struct iv2d_circle const*)region;
-    return iv32_sub(iv32_sqrt(iv32_add(iv32_square(iv32_sub(x, as_iv32(c->x))),
-                                       iv32_square(iv32_sub(y, as_iv32(c->y))))),
-                  as_iv32(c->r));
+
+    iv32 const dx = iv32_sub(x, as_iv32(c->x)),
+               dy = iv32_sub(y, as_iv32(c->y));
+
+    iv32 const len = iv32_sqrt(iv32_add(iv32_square(dx),
+                                        iv32_square(dy)));
+
+    return iv32_sub(len, as_iv32(c->r));
 }
 
 iv32 iv2d_capsule(struct iv2d_region const *region, iv32 x, iv32 y) {
@@ -16,15 +21,20 @@ iv32 iv2d_capsule(struct iv2d_region const *region, iv32 x, iv32 y) {
     iv32 const px = iv32_sub(x, as_iv32(c->x0)),
                py = iv32_sub(y, as_iv32(c->y0));
 
-    iv32 const t = iv32_mul(iv32_add(iv32_mul(px, as_iv32(dx)),
-                                     iv32_mul(py, as_iv32(dy))),
-                            as_iv32(1 / (dx*dx + dy*dy)));
+    iv32 const dot = iv32_add(iv32_mul(px, as_iv32(dx)),
+                              iv32_mul(py, as_iv32(dy)));
+
+    iv32 const t = iv32_mul(dot, as_iv32(1 / (dx*dx + dy*dy)));
 
     iv32 const h = iv32_max(as_iv32(0), iv32_min(t, as_iv32(1)));
 
-    return iv32_sub(iv32_sqrt(iv32_add(iv32_square(iv32_sub(px, iv32_mul(h, as_iv32(dx)))),
-                                       iv32_square(iv32_sub(py, iv32_mul(h, as_iv32(dy)))))),
-                    as_iv32(c->r));
+    iv32 const hx = iv32_sub(px, iv32_mul(h, as_iv32(dx))),
+               hy = iv32_sub(py, iv32_mul(h, as_iv32(dy)));
+
+    iv32 const len = iv32_sqrt(iv32_add(iv32_square(hx),
+                                        iv32_square(hy)));
+
+    return iv32_sub(len, as_iv32(c->r));
 }
 
 iv32 iv2d_union(struct iv2d_region const *region, iv32 x, iv32 y) {


### PR DESCRIPTION
## Summary
- split complex expressions in `iv2d_circle` and `iv2d_capsule`
- keep style consistent with codebase

## Testing
- `ninja`
- `ninja -f dbg` *(fails: AddressSanitizer leak)*

------
https://chatgpt.com/codex/tasks/task_e_68533faea2dc8326bfef5e8fc457d2fb