### PR TITLE
Add div operation to IV utilities

### DIFF
--- a/iv.h
+++ b/iv.h
@@ -98,6 +98,10 @@ static inline iv32 iv32_inv(iv32 x) {
     };
 }
 
+static inline iv32 iv32_div(iv32 x, iv32 y) {
+    return iv32_mul(x, iv32_inv(y));
+}
+
 static inline half4 if_then_else16(short4 mask, half4 t, half4 e) {
     return (half4)( ( mask & (short4)t)
                   | (~mask & (short4)e) );
@@ -193,4 +197,8 @@ static inline iv16 iv16_inv(iv16 x) {
         if_then_else16(x.lo > 0 | x.hi < 0 | (x.lo >= 0 & x.hi > 0), 1/x.hi, (half4){0} - 1/0.0f),
         if_then_else16(x.lo > 0 | x.hi < 0 | (x.lo < 0 & x.hi <= 0), 1/x.lo, (half4){0} + 1/0.0f),
     };
+}
+
+static inline iv16 iv16_div(iv16 x, iv16 y) {
+    return iv16_mul(x, iv16_inv(y));
 }

--- a/iv2d_vm.c
+++ b/iv2d_vm.c
@@ -4,7 +4,7 @@
 #include <string.h>
 
 struct inst {
-    enum { RET,IMM,UNI,X,Y,ABS,SQT,SQR,INV,ADD,SUB,MUL,MIN,MAX} op;
+    enum { RET,IMM,UNI,X,Y,ABS,SQT,SQR,INV,ADD,SUB,MUL,DIV,MIN,MAX} op;
     int          lhs,rhs;
     float        imm;
     float const *ptr;
@@ -46,6 +46,7 @@ int iv2d_inv   (builder *b, int v) { return push(b, (struct inst){.op=INV, .rhs=
 int iv2d_sub(builder *b, int l, int r) { return push(b, (struct inst){.op=SUB, .lhs=l, .rhs=r}); }
 int iv2d_add(builder *b, int l, int r) { return push(b, (struct inst){.op=ADD, .lhs=l, .rhs=r}); }
 int iv2d_mul(builder *b, int l, int r) { return push(b, (struct inst){.op=MUL, .lhs=l, .rhs=r}); }
+int iv2d_div(builder *b, int l, int r) { return push(b, (struct inst){.op=DIV, .lhs=l, .rhs=r}); }
 int iv2d_min(builder *b, int l, int r) { return push(b, (struct inst){.op=MIN, .lhs=l, .rhs=r}); }
 int iv2d_max(builder *b, int l, int r) { return push(b, (struct inst){.op=MAX, .lhs=l, .rhs=r}); }
 
@@ -87,6 +88,7 @@ static iv32 run_program(struct iv2d_region const *region, iv32 x, iv32 y) {
             case ADD: *next++ = iv32_add(v[inst->lhs], v[inst->rhs]); break;
             case SUB: *next++ = iv32_sub(v[inst->lhs], v[inst->rhs]); break;
             case MUL: *next++ = iv32_mul(v[inst->lhs], v[inst->rhs]); break;
+            case DIV: *next++ = iv32_div(v[inst->lhs], v[inst->rhs]); break;
             case MIN: *next++ = iv32_min(v[inst->lhs], v[inst->rhs]); break;
             case MAX: *next++ = iv32_max(v[inst->lhs], v[inst->rhs]); break;
 

--- a/iv2d_vm.h
+++ b/iv2d_vm.h
@@ -14,6 +14,7 @@ int iv2d_uni(struct iv2d_builder*, float const*);
 int iv2d_add(struct iv2d_builder*, int,int);
 int iv2d_sub(struct iv2d_builder*, int,int);
 int iv2d_mul(struct iv2d_builder*, int,int);
+int iv2d_div(struct iv2d_builder*, int,int);
 int iv2d_mad(struct iv2d_builder*, int,int,int);
 
 int iv2d_min(struct iv2d_builder*, int,int);

--- a/iv2d_vm_test.c
+++ b/iv2d_vm_test.c
@@ -63,6 +63,26 @@ static void test_mul(void) {
     }
 }
 
+static void test_div(void) {
+    __attribute__((cleanup(free_cleanup)))
+    struct iv2d_region const *region;
+    {
+        struct iv2d_builder *b = iv2d_builder();
+        int const x = iv2d_x(b),
+                  y = iv2d_y(b);
+        region = iv2d_ret(b, iv2d_div(b,x,y));
+    }
+
+    iv32 x = (iv32){{6,-6,-2,3}, {8,8,4,-3}},
+         y = (iv32){{2,-2,-1,3}, {2,4,2,-1}};
+    iv32 z = region->eval(region, x,y);
+    iv32 e = iv32_div(x,y);
+    for (int i = 0; i < 4; i++) {
+        expect(equiv(z.lo[i], e.lo[i]));
+        expect(equiv(z.hi[i], e.hi[i]));
+    }
+}
+
 static void test_min(void) {
     __attribute__((cleanup(free_cleanup)))
     struct iv2d_region const *region;
@@ -207,6 +227,7 @@ int main(void) {
     test_sub();
     test_add();
     test_mul();
+    test_div();
     test_min();
     test_max();
     test_sqrt();

--- a/iv_test.c
+++ b/iv_test.c
@@ -56,6 +56,25 @@ static void test_mul16(void) {
     expect(equiv(z.hi[3],  15));
 }
 
+static void test_div(void) {
+    iv32 y = (iv32){{2,-2,-1,3},{2,4,2,-1}};
+    iv32 z = iv32_div((iv32){{6,-6,-2,3},{8,8,4,-3}}, y);
+    iv32 e = iv32_mul((iv32){{6,-6,-2,3},{8,8,4,-3}}, iv32_inv(y));
+    for (int i = 0; i < 4; i++) {
+        expect(equiv(z.lo[i], e.lo[i]));
+        expect(equiv(z.hi[i], e.hi[i]));
+    }
+}
+static void test_div16(void) {
+    iv16 y = (iv16){{2,-2,-1,3},{2,4,2,-1}};
+    iv16 z = iv16_div((iv16){{6,-6,-2,3},{8,8,4,-3}}, y);
+    iv16 e = iv16_mul((iv16){{6,-6,-2,3},{8,8,4,-3}}, iv16_inv(y));
+    for (int i = 0; i < 4; i++) {
+        expect(equiv(z.lo[i], e.lo[i]));
+        expect(equiv(z.hi[i], e.hi[i]));
+    }
+}
+
 
 static void test_mad(void) {
     iv32 z = iv32_mad((iv32){{1,-1,-2,-1},{2,2,2,1}},
@@ -329,6 +348,7 @@ int main(void) {
     test_add();    test_add16();
     test_sub();    test_sub16();
     test_mul();    test_mul16();
+    test_div();    test_div16();
     test_mad();    test_mad16();
     test_min();    test_min16();
     test_max();    test_max16();

--- a/prospero.c
+++ b/prospero.c
@@ -32,14 +32,14 @@ struct iv2d_region const* prospero_region(float const *w, float const *h) {
             continue;
         }
         if (starts_with(c, "var-x")) { // Scale [0,w) x to [-1,1] as x * (2/(w-1)) - 1
-            int const m = iv2d_mul(b, iv2d_imm(b,+2)
-                                    , iv2d_inv(b, iv2d_sub(b, iv2d_uni(b,w), iv2d_imm(b,+1))));
+            int const m = iv2d_div(b, iv2d_imm(b,+2)
+                                   , iv2d_sub(b, iv2d_uni(b,w), iv2d_imm(b,+1)));
             val[id] = iv2d_mad(b, iv2d_x(b), m, iv2d_imm(b,-1));
             continue;
         }
         if (starts_with(c, "var-y")) { // Scale [0,h) y to [-1,1], as above, flipped.
-            int const m = iv2d_mul(b, iv2d_imm(b,-2)
-                                    , iv2d_inv(b, iv2d_sub(b, iv2d_uni(b,h), iv2d_imm(b,+1))));
+            int const m = iv2d_div(b, iv2d_imm(b,-2)
+                                   , iv2d_sub(b, iv2d_uni(b,h), iv2d_imm(b,+1)));
             val[id] = iv2d_mad(b, iv2d_y(b), m, iv2d_imm(b,+1));
             continue;
         }


### PR DESCRIPTION
## Summary
- add `iv32_div` and `iv16_div`
- add `DIV` opcode and `iv2d_div` builder helper
- use new helper in Prosperos VM parser
- test `div` for both vector sizes and in VM

## Testing
- `ninja`
- `ninja -f dbg`

------
https://chatgpt.com/codex/tasks/task_e_68587dbf79048326bec034e52aca430d