### PR TITLE
Remove SDL dependency from gold

### DIFF
--- a/build-common.ninja
+++ b/build-common.ninja
@@ -41,14 +41,12 @@ build $outdir/demo: link $outdir/demo.o $
     flags = -L/opt/homebrew/lib -lSDL2
 
 build $outdir/gold.o: compile gold.c
-    flags = -isystem /opt/homebrew/include
 build $outdir/gold: link $outdir/gold.o $
                          $outdir/slides.o $
                          $outdir/iv2d.o $
                          $outdir/iv2d_regions.o $
                          $outdir/iv2d_vm.o $
                          $outdir/prospero.o
-    flags = -L/opt/homebrew/lib -lSDL2
 
 build $outdir/bench.o: compile bench.c
 build $outdir/bench: link $outdir/bench.o $

--- a/gold.c
+++ b/gold.c
@@ -1,6 +1,5 @@
 #include "slides.h"
 #include "iv2d_regions.h"
-#include "len.h"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Weverything"
 #pragma clang attribute push (__attribute__((no_sanitize("integer", "undefined"))), apply_to=function)
@@ -8,31 +7,39 @@
 #include "stb/stb_image_write.h"
 #pragma clang attribute pop
 #pragma clang diagnostic pop
-#include <SDL2/SDL.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-struct quad {
-    struct { float x,y; SDL_Color c; } vertex[6];
-};
-
 struct ctx {
-    struct quad *quad;
-    int quads, quad_cap;
+    uint8_t *pixels;
+    int w;
+    int :32;
 };
 
-static void queue_rect(void *arg, float l, float t, float r, float b, float cov) {
+static void paint_rect(void *arg, float l, float t, float r, float b, float cov) {
     struct ctx *ctx = arg;
-    if (ctx->quad_cap == ctx->quads) {
-        ctx->quad_cap = ctx->quad_cap ? 2 * ctx->quad_cap : 1;
-        ctx->quad = realloc(ctx->quad, (size_t)ctx->quad_cap * sizeof *ctx->quad);
+    int const x0 = (int)l, y0 = (int)t,
+              x1 = (int)r, y1 = (int)b;
+    unsigned const a = (unsigned)(uint8_t)(cov * 255);
+    if (!a) { return; }
+
+    // Blend (127,127,127,a) over white (255,255,255,255).
+    // Match SDL2 geometry renderer's >>8 approximation for division by 255.
+    uint8_t const gray = (uint8_t)((127u * a + 255u * (256u - a)) >> 8);
+    uint8_t const   oa = (uint8_t)(a + ((255u * (255u - a)) >> 8));
+
+    for (int y = y0; y < y1; y++) {
+        uint8_t *row = ctx->pixels + y * ctx->w * 4 + x0 * 4;
+        for (int x = x0; x < x1; x++) {
+            row[0] = gray;
+            row[1] = gray;
+            row[2] = gray;
+            row[3] = oa;
+            row += 4;
+        }
     }
-    SDL_Color const c = {127,127,127, (uint8_t)(cov*255)};
-    ctx->quad[ctx->quads++] = (struct quad) {{
-        {l,t,c}, {r,t,c}, {l,b,c},
-        {r,t,c}, {r,b,c}, {l,b,c},
-    }};
 }
 
 static void write_to_stdout(void *ctx, void *buf, int len) {
@@ -58,21 +65,12 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormat(
-        0, w, h, 32, SDL_PIXELFORMAT_RGBA32);
-    SDL_Renderer *renderer = SDL_CreateSoftwareRenderer(surface);
-    SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-    SDL_SetRenderDrawColor    (renderer, 255,255,255,255);
-    SDL_RenderClear           (renderer);
-
     struct slides slides;
     slides_init(&slides, w, h, 0);
 
     if (slide_idx < 0 || slide_idx >= slides.count) {
         fprintf(stderr, "slide %d out of range [0,%d)\n", slide_idx, slides.count);
         slides_fini(&slides);
-        SDL_DestroyRenderer(renderer);
-        SDL_FreeSurface(surface);
         return 1;
     }
 
@@ -82,26 +80,16 @@ int main(int argc, char *argv[]) {
         region = &stroke_r.region;
     }
 
-    struct ctx ctx = {0};
-    iv2d_cover(region, 0,0,w,h, quality, queue_rect,&ctx);
+    uint8_t *pixels = malloc((size_t)(w * h) * 4);
+    memset(pixels, 255, (size_t)(w * h) * 4);
+
+    struct ctx ctx = { pixels, w };
+    iv2d_cover(region, 0,0,w,h, quality, paint_rect,&ctx);
 
     slides_fini(&slides);
 
-    SDL_RenderGeometryRaw(renderer, NULL
-                                  , &ctx.quad->vertex->x, sizeof *ctx.quad->vertex
-                                  , &ctx.quad->vertex->c, sizeof *ctx.quad->vertex
-                                  , NULL, 0
-                                  , 6 * ctx.quads
-                                  , NULL, 0, 0);
+    stbi_write_png_to_func(write_to_stdout, NULL, w,h,4, pixels, w*4);
 
-    SDL_Surface *rgba = SDL_CreateRGBSurfaceWithFormat(0,w,h,32,SDL_PIXELFORMAT_RGBA32);
-    SDL_RenderReadPixels(renderer, NULL,
-                         SDL_PIXELFORMAT_RGBA32, rgba->pixels, rgba->pitch);
-    stbi_write_png_to_func(write_to_stdout, NULL, w,h,4, rgba->pixels, rgba->pitch);
-
-    SDL_FreeSurface(rgba);
-    SDL_DestroyRenderer(renderer);
-    SDL_FreeSurface(surface);
-    free(ctx.quad);
+    free(pixels);
     return 0;
 }


### PR DESCRIPTION
## Summary
- Replace SDL software renderer in `gold` with direct pixel compositing (allocate RGBA buffer, blend gray-over-white rects manually)
- Remove SDL link flags from gold's build target

## Test plan
- [x] Full `ninja` build passes (all 88 targets including gold image generation and comparison)
- [x] All 28 gold images match bit-for-bit between dbg and release builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)